### PR TITLE
Bug-2054841: Increase services unit test coverage to 100%

### DIFF
--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -7,13 +7,30 @@ from tests.conftest import IS_WINDOWS
 from treeherder.etl.tasks.pulse_tasks import (
     store_pulse_tasks,
     store_pulse_tasks_classification,
+    store_pulse_pushes,
 )
-from treeherder.services.pulse.consumers import Consumers, JointConsumer, PulseConsumer
+from treeherder.services.pulse.consumers import (
+    Consumers,
+    JointConsumer,
+    PulseConsumer,
+    TaskConsumer,
+    MozciClassificationConsumer,
+    PushConsumer,
+    prepare_consumers,
+    prepare_joint_consumers,
+    TASKCLUSTER_TASK_BINDINGS,
+    GITHUB_PUSH_BINDINGS,
+    HGMO_PUSH_BINDINGS,
+    MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS,
+    MOZCI_CLASSIFICATION_TESTING_BINDINGS,
+)
+from treeherder.services.pulse.exchange import get_exchange
 
 from .utils import create_and_destroy_exchange
 
 
 def test_consumers():
+    """Test parallel consumers run setup and start threads as expected."""
     class TestConsumer:
         def prepare(self):
             self.prepared = True
@@ -35,6 +52,7 @@ def test_consumers():
 
 @pytest.mark.skipif(IS_WINDOWS, reason="celery does not work on windows")
 def test_pulse_consumer(pulse_connection):
+    """Test PulseConsumer setup prepares connection and exchange."""
     class TestConsumer(PulseConsumer):
         queue_suffix = "test"
 
@@ -56,6 +74,7 @@ def test_pulse_consumer(pulse_connection):
 
 
 def test_joint_consumer_on_message_do_not_call_classification_ingestion(monkeypatch):
+    """Test JointConsumer on_message does not trigger mozci classification if not a mozci task."""
     mock_called = False
 
     def mock_store_pulse_tasks_classification(args, queue):
@@ -92,6 +111,7 @@ def test_joint_consumer_on_message_do_not_call_classification_ingestion(monkeypa
 
 
 def test_joint_consumer_on_message_call_classification_ingestion(monkeypatch):
+    """Test JointConsumer on_message triggers mozci classification task when routing key matches."""
     mock_called = False
 
     def mock_store_pulse_tasks_classification(args, queue):
@@ -125,3 +145,302 @@ def test_joint_consumer_on_message_call_classification_ingestion(monkeypatch):
     consumer.on_message(None, message)
 
     assert mock_called
+
+
+# Additional Unit Tests for 100% Coverage of treeherder/services/pulse/consumers.py
+
+class DummyPulseConsumer(PulseConsumer):
+    queue_suffix = "dummy"
+
+    def on_message(self, body, message):
+        pass
+
+
+def test_pulse_consumer_bindings_default():
+    """Test base PulseConsumer returns empty bindings by default."""
+    cons = DummyPulseConsumer(
+        {
+            "root_url": "https://firefox-ci-tc.services.mozilla.com",
+            "pulse_url": "memory://",
+        },
+        None,
+    )
+    assert cons.bindings() == []
+
+
+def test_get_consumers():
+    """Test that get_consumers instantiates a consumer object for each configured config dict."""
+    cons = DummyPulseConsumer(
+        {
+            "root_url": "https://firefox-ci-tc.services.mozilla.com",
+            "pulse_url": "memory://",
+        },
+        None,
+    )
+    cons.consumers = [{"key": "value"}]
+    mock_consumer_class = MagicMock()
+    cons.get_consumers(mock_consumer_class, None)
+    mock_consumer_class.assert_called_once_with(key="value")
+
+
+def test_pulse_consumer_bind_and_unbind(pulse_connection, monkeypatch):
+    """Test PulseConsumer can bind, re-bind, unbind, and close connection."""
+    cons = DummyPulseConsumer(
+        {
+            "root_url": "https://firefox-ci-tc.services.mozilla.com",
+            "pulse_url": "memory://",
+        },
+        None,
+    )
+    # Bind
+    exchange = get_exchange(pulse_connection, "test_exchange", create=True)
+    binding = cons.bind_to(exchange, "test_routing_key")
+    assert binding == "test_exchange test_routing_key"
+    assert len(cons.consumers) == 1
+
+    # Call bind_to again (exercise the 'else' branch of 'if not self.queue:')
+    mock_bind = MagicMock()
+    monkeypatch.setattr(cons.queue, "bind_to", mock_bind)
+    cons.bind_to(exchange, "another_key")
+    mock_bind.assert_called_once_with(exchange=exchange, routing_key="another_key")
+
+    # Unbind
+    mock_unbind = MagicMock()
+    monkeypatch.setattr(cons.queue, "unbind_from", mock_unbind)
+    cons.unbind_from(exchange, "test_routing_key")
+    mock_unbind.assert_called_once_with(exchange, "test_routing_key")
+
+    # Close
+    mock_release = MagicMock()
+    monkeypatch.setattr(cons.connection, "release", mock_release)
+    cons.close()
+    mock_release.assert_called_once()
+
+
+def test_pulse_consumer_prune_bindings(pulse_connection, monkeypatch):
+    """Test PulseConsumer correctly prunes stale bindings."""
+    cons = DummyPulseConsumer(
+        {
+            "root_url": "https://firefox-ci-tc.services.mozilla.com",
+            "pulse_url": "memory://",
+        },
+        None,
+    )
+    exchange = get_exchange(pulse_connection, "test_exchange", create=True)
+    cons.bind_to(exchange, "new_key")
+
+    # Case 1: get_bindings succeeds and has an old binding to prune
+    mock_fetch = MagicMock(return_value={
+        "bindings": [
+            {"source": "test_exchange", "routing_key": "new_key"},
+            {"source": "test_exchange", "routing_key": "old_key"},
+        ]
+    })
+    monkeypatch.setattr("treeherder.services.pulse.consumers.fetch_json", mock_fetch)
+
+    mock_unbind = MagicMock()
+    monkeypatch.setattr(cons, "unbind_from", mock_unbind)
+
+    cons.prune_bindings(["test_exchange new_key"])
+    mock_unbind.assert_called_once()
+
+    # Case 2: get_bindings raises an exception (should handle and log error but not crash)
+    mock_fetch.side_effect = Exception("HTTP error")
+    cons.prune_bindings(["test_exchange new_key"])  # should not raise an error
+
+
+def test_pulse_consumer_prepare(pulse_connection, monkeypatch):
+    """Test prepare method sets up all routing key bindings and prunes stale ones."""
+    class SimpleConsumer(PulseConsumer):
+        queue_suffix = "simple"
+        def bindings(self):
+            return ["test_exchange.key1:key2"]
+
+        def on_message(self, body, message):
+            pass
+
+    cons = SimpleConsumer(
+        {
+            "root_url": "https://firefox-ci-tc.services.mozilla.com",
+            "pulse_url": "memory://",
+        },
+        build_routing_key=lambda r: f"prefix.{r}",
+    )
+
+    # Mock get_exchange to return a dummy exchange
+    monkeypatch.setattr("treeherder.services.pulse.consumers.get_exchange", lambda conn, name: MagicMock(name=name))
+
+    # Mock bind_to and prune_bindings
+    bound_keys = []
+    monkeypatch.setattr(cons, "bind_to", lambda exchange, key: bound_keys.append(key) or f"{exchange.name} {key}")
+    monkeypatch.setattr(cons, "prune_bindings", lambda bindings: None)
+
+    cons.prepare()
+    assert bound_keys == ["prefix.key1", "prefix.key2"]
+
+
+def test_task_consumer(monkeypatch):
+    """Test TaskConsumer bindings and asynchronous task routing logic on message receipt."""
+    cons = TaskConsumer({"root_url": "https://foo.com", "pulse_url": "memory://"}, None)
+    assert cons.bindings() == TASKCLUSTER_TASK_BINDINGS
+
+    mock_apply = MagicMock()
+    monkeypatch.setattr(store_pulse_tasks, "apply_async", mock_apply)
+
+    message = MagicMock()
+    message.delivery_info = {"exchange": "ex", "routing_key": "rk"}
+    cons.on_message("my-body", message)
+    mock_apply.assert_called_once_with(
+        args=["my-body", "ex", "rk", "https://foo.com"], queue="store_pulse_tasks"
+    )
+    message.ack.assert_called_once()
+
+
+def test_mozci_classification_consumer(monkeypatch):
+    """Test MozciClassificationConsumer environment configurations and message routing."""
+    # Default production env
+    cons = MozciClassificationConsumer({"root_url": "https://foo.com", "pulse_url": "memory://"}, None)
+    assert cons.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
+
+    # Testing env
+    monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "testing")
+    assert cons.bindings() == MOZCI_CLASSIFICATION_TESTING_BINDINGS
+
+    # Invalid env (should log warning but default to production)
+    monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "invalid")
+    assert cons.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
+
+    # on_message
+    mock_apply = MagicMock()
+    monkeypatch.setattr(store_pulse_tasks_classification, "apply_async", mock_apply)
+
+    message = MagicMock()
+    message.delivery_info = {"exchange": "ex", "routing_key": "rk"}
+    cons.on_message("my-body", message)
+    mock_apply.assert_called_once_with(
+        args=["my-body", "ex", "rk", "https://foo.com"], queue="store_pulse_tasks_classification"
+    )
+    message.ack.assert_called_once()
+
+
+def test_push_consumer(monkeypatch):
+    """Test PushConsumer bindings conditionally active for hgmo and github source types."""
+    # Both hgmo and github disabled
+    cons = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": False}, None)
+    assert cons.bindings() == []
+
+    # hgmo enabled
+    cons_hg = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": False}, None)
+    assert cons_hg.bindings() == HGMO_PUSH_BINDINGS
+
+    # github enabled
+    cons_git = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": True}, None)
+    assert cons_git.bindings() == GITHUB_PUSH_BINDINGS
+
+    # both enabled
+    cons_both = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": True}, None)
+    assert cons_both.bindings() == HGMO_PUSH_BINDINGS + GITHUB_PUSH_BINDINGS
+
+    # on_message
+    mock_apply = MagicMock()
+    monkeypatch.setattr(store_pulse_pushes, "apply_async", mock_apply)
+
+    message = MagicMock()
+    message.delivery_info = {"exchange": "ex", "routing_key": "rk"}
+    cons_both.on_message("my-body", message)
+    mock_apply.assert_called_once_with(
+        args=["my-body", "ex", "rk", "https://foo.com"], queue="store_pulse_pushes"
+    )
+    message.ack.assert_called_once()
+
+
+def test_joint_consumer_bindings(monkeypatch):
+    """Test JointConsumer bindings collection based on enabled flags in source."""
+    # Test various branches in JointConsumer.bindings()
+    # 1. hgmo and github
+    cons1 = JointConsumer({"hgmo": True, "github": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    assert cons1.bindings() == HGMO_PUSH_BINDINGS + GITHUB_PUSH_BINDINGS
+
+    # 2. tasks
+    cons2 = JointConsumer({"tasks": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    assert cons2.bindings() == TASKCLUSTER_TASK_BINDINGS
+
+    # 3. mozci-classification testing env
+    monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "testing")
+    cons3 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    assert cons3.bindings() == MOZCI_CLASSIFICATION_TESTING_BINDINGS
+
+    # 4. mozci-classification production env
+    monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "production")
+    cons4 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    assert cons4.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
+
+    # 5. mozci-classification invalid env (should fallback to production)
+    monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "invalid")
+    cons5 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    assert cons5.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
+
+
+def test_joint_consumer_on_message_non_taskcluster(monkeypatch):
+    """Test JointConsumer routes push-related messages correctly."""
+    # If exchange is NOT taskcluster-queue, it calls store_pulse_pushes
+    mock_store_pulse_pushes = MagicMock()
+    monkeypatch.setattr(store_pulse_pushes, "apply_async", mock_store_pulse_pushes)
+
+    cons = JointConsumer({"root_url": "https://foo.com", "pulse_url": "memory://"}, None)
+    message = MagicMock()
+    message.delivery_info = {"exchange": "exchange/hgpushes/v1", "routing_key": "rk"}
+    cons.on_message("body", message)
+
+    mock_store_pulse_pushes.assert_called_once_with(
+        args=["body", "exchange/hgpushes/v1", "rk", "https://foo.com"], queue="store_pulse_pushes"
+    )
+    message.ack.assert_called_once()
+
+
+def test_consumers_runner():
+    """Test Consumers runner triggers prepare and executes thread routines."""
+    # Test real execution thread spawn and join
+    mock_prepare = MagicMock()
+    mock_run = MagicMock()
+
+    class DummyConsumer:
+        def prepare(self):
+            mock_prepare()
+        def run(self):
+            mock_run()
+
+    cons = Consumers([DummyConsumer(), DummyConsumer()])
+    cons.run()
+
+    assert mock_prepare.call_count == 2
+    assert mock_run.call_count == 2
+
+
+def test_prepare_consumers_factory():
+    """Test prepare_consumers factory correctly initializes Consumers container with list of class instances."""
+    class DummyConsumerClass:
+        def __init__(self, source, build_routing_key):
+            self.source = source
+            self.build_routing_key = build_routing_key
+
+    consumers_obj = prepare_consumers(DummyConsumerClass, [{"src": 1}], "key")
+    assert isinstance(consumers_obj, Consumers)
+    assert len(consumers_obj.consumers) == 1
+    assert consumers_obj.consumers[0].source == {"src": 1}
+    assert consumers_obj.consumers[0].build_routing_key == "key"
+
+
+def test_prepare_joint_consumers_factory():
+    """Test prepare_joint_consumers factory correctly unpacks tuple arguments and instantiates consumers."""
+    class DummyConsumerClass:
+        def __init__(self, source, build_routing_key):
+            self.source = source
+            self.build_routing_key = build_routing_key
+
+    listening_params = (DummyConsumerClass, [{"src": 2}], ["key2"])
+    consumers_obj = prepare_joint_consumers(listening_params)
+    assert isinstance(consumers_obj, Consumers)
+    assert len(consumers_obj.consumers) == 1
+    assert consumers_obj.consumers[0].source == {"src": 2}
+    assert consumers_obj.consumers[0].build_routing_key == "key2"

--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -5,24 +5,24 @@ from django.conf import settings
 
 from tests.conftest import IS_WINDOWS
 from treeherder.etl.tasks.pulse_tasks import (
+    store_pulse_pushes,
     store_pulse_tasks,
     store_pulse_tasks_classification,
-    store_pulse_pushes,
 )
 from treeherder.services.pulse.consumers import (
-    Consumers,
-    JointConsumer,
-    PulseConsumer,
-    TaskConsumer,
-    MozciClassificationConsumer,
-    PushConsumer,
-    prepare_consumers,
-    prepare_joint_consumers,
-    TASKCLUSTER_TASK_BINDINGS,
     GITHUB_PUSH_BINDINGS,
     HGMO_PUSH_BINDINGS,
     MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS,
     MOZCI_CLASSIFICATION_TESTING_BINDINGS,
+    TASKCLUSTER_TASK_BINDINGS,
+    Consumers,
+    JointConsumer,
+    MozciClassificationConsumer,
+    PulseConsumer,
+    PushConsumer,
+    TaskConsumer,
+    prepare_consumers,
+    prepare_joint_consumers,
 )
 from treeherder.services.pulse.exchange import get_exchange
 
@@ -31,6 +31,7 @@ from .utils import create_and_destroy_exchange
 
 def test_consumers():
     """Test parallel consumers run setup and start threads as expected."""
+
     class TestConsumer:
         def prepare(self):
             self.prepared = True
@@ -53,6 +54,7 @@ def test_consumers():
 @pytest.mark.skipif(IS_WINDOWS, reason="celery does not work on windows")
 def test_pulse_consumer(pulse_connection):
     """Test PulseConsumer setup prepares connection and exchange."""
+
     class TestConsumer(PulseConsumer):
         queue_suffix = "test"
 
@@ -149,6 +151,7 @@ def test_joint_consumer_on_message_call_classification_ingestion(monkeypatch):
 
 # Additional Unit Tests for 100% Coverage of treeherder/services/pulse/consumers.py
 
+
 class DummyPulseConsumer(PulseConsumer):
     queue_suffix = "dummy"
 
@@ -230,12 +233,14 @@ def test_pulse_consumer_prune_bindings(pulse_connection, monkeypatch):
     cons.bind_to(exchange, "new_key")
 
     # Case 1: get_bindings succeeds and has an old binding to prune
-    mock_fetch = MagicMock(return_value={
-        "bindings": [
-            {"source": "test_exchange", "routing_key": "new_key"},
-            {"source": "test_exchange", "routing_key": "old_key"},
-        ]
-    })
+    mock_fetch = MagicMock(
+        return_value={
+            "bindings": [
+                {"source": "test_exchange", "routing_key": "new_key"},
+                {"source": "test_exchange", "routing_key": "old_key"},
+            ]
+        }
+    )
     monkeypatch.setattr("treeherder.services.pulse.consumers.fetch_json", mock_fetch)
 
     mock_unbind = MagicMock()
@@ -251,8 +256,10 @@ def test_pulse_consumer_prune_bindings(pulse_connection, monkeypatch):
 
 def test_pulse_consumer_prepare(pulse_connection, monkeypatch):
     """Test prepare method sets up all routing key bindings and prunes stale ones."""
+
     class SimpleConsumer(PulseConsumer):
         queue_suffix = "simple"
+
         def bindings(self):
             return ["test_exchange.key1:key2"]
 
@@ -268,11 +275,15 @@ def test_pulse_consumer_prepare(pulse_connection, monkeypatch):
     )
 
     # Mock get_exchange to return a dummy exchange
-    monkeypatch.setattr("treeherder.services.pulse.consumers.get_exchange", lambda conn, name: MagicMock(name=name))
+    monkeypatch.setattr(
+        "treeherder.services.pulse.consumers.get_exchange", lambda conn, name: MagicMock(name=name)
+    )
 
     # Mock bind_to and prune_bindings
     bound_keys = []
-    monkeypatch.setattr(cons, "bind_to", lambda exchange, key: bound_keys.append(key) or f"{exchange.name} {key}")
+    monkeypatch.setattr(
+        cons, "bind_to", lambda exchange, key: bound_keys.append(key) or f"{exchange.name} {key}"
+    )
     monkeypatch.setattr(cons, "prune_bindings", lambda bindings: None)
 
     cons.prepare()
@@ -299,7 +310,9 @@ def test_task_consumer(monkeypatch):
 def test_mozci_classification_consumer(monkeypatch):
     """Test MozciClassificationConsumer environment configurations and message routing."""
     # Default production env
-    cons = MozciClassificationConsumer({"root_url": "https://foo.com", "pulse_url": "memory://"}, None)
+    cons = MozciClassificationConsumer(
+        {"root_url": "https://foo.com", "pulse_url": "memory://"}, None
+    )
     assert cons.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
 
     # Testing env
@@ -326,19 +339,31 @@ def test_mozci_classification_consumer(monkeypatch):
 def test_push_consumer(monkeypatch):
     """Test PushConsumer bindings conditionally active for hgmo and github source types."""
     # Both hgmo and github disabled
-    cons = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": False}, None)
+    cons = PushConsumer(
+        {"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": False},
+        None,
+    )
     assert cons.bindings() == []
 
     # hgmo enabled
-    cons_hg = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": False}, None)
+    cons_hg = PushConsumer(
+        {"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": False},
+        None,
+    )
     assert cons_hg.bindings() == HGMO_PUSH_BINDINGS
 
     # github enabled
-    cons_git = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": True}, None)
+    cons_git = PushConsumer(
+        {"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": False, "github": True},
+        None,
+    )
     assert cons_git.bindings() == GITHUB_PUSH_BINDINGS
 
     # both enabled
-    cons_both = PushConsumer({"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": True}, None)
+    cons_both = PushConsumer(
+        {"root_url": "https://foo.com", "pulse_url": "memory://", "hgmo": True, "github": True},
+        None,
+    )
     assert cons_both.bindings() == HGMO_PUSH_BINDINGS + GITHUB_PUSH_BINDINGS
 
     # on_message
@@ -358,26 +383,40 @@ def test_joint_consumer_bindings(monkeypatch):
     """Test JointConsumer bindings collection based on enabled flags in source."""
     # Test various branches in JointConsumer.bindings()
     # 1. hgmo and github
-    cons1 = JointConsumer({"hgmo": True, "github": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    cons1 = JointConsumer(
+        {"hgmo": True, "github": True, "pulse_url": "memory://", "root_url": "https://foo.com"},
+        None,
+    )
     assert cons1.bindings() == HGMO_PUSH_BINDINGS + GITHUB_PUSH_BINDINGS
 
     # 2. tasks
-    cons2 = JointConsumer({"tasks": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    cons2 = JointConsumer(
+        {"tasks": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None
+    )
     assert cons2.bindings() == TASKCLUSTER_TASK_BINDINGS
 
     # 3. mozci-classification testing env
     monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "testing")
-    cons3 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    cons3 = JointConsumer(
+        {"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"},
+        None,
+    )
     assert cons3.bindings() == MOZCI_CLASSIFICATION_TESTING_BINDINGS
 
     # 4. mozci-classification production env
     monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "production")
-    cons4 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    cons4 = JointConsumer(
+        {"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"},
+        None,
+    )
     assert cons4.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
 
     # 5. mozci-classification invalid env (should fallback to production)
     monkeypatch.setenv("PULSE_MOZCI_ENVIRONMENT", "invalid")
-    cons5 = JointConsumer({"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"}, None)
+    cons5 = JointConsumer(
+        {"mozci-classification": True, "pulse_url": "memory://", "root_url": "https://foo.com"},
+        None,
+    )
     assert cons5.bindings() == MOZCI_CLASSIFICATION_PRODUCTION_BINDINGS
 
 
@@ -407,6 +446,7 @@ def test_consumers_runner():
     class DummyConsumer:
         def prepare(self):
             mock_prepare()
+
         def run(self):
             mock_run()
 
@@ -419,6 +459,7 @@ def test_consumers_runner():
 
 def test_prepare_consumers_factory():
     """Test prepare_consumers factory correctly initializes Consumers container with list of class instances."""
+
     class DummyConsumerClass:
         def __init__(self, source, build_routing_key):
             self.source = source
@@ -433,6 +474,7 @@ def test_prepare_consumers_factory():
 
 def test_prepare_joint_consumers_factory():
     """Test prepare_joint_consumers factory correctly unpacks tuple arguments and instantiates consumers."""
+
     class DummyConsumerClass:
         def __init__(self, source, build_routing_key):
             self.source = source

--- a/tests/services/pulse/test_consumers.py
+++ b/tests/services/pulse/test_consumers.py
@@ -149,9 +149,6 @@ def test_joint_consumer_on_message_call_classification_ingestion(monkeypatch):
     assert mock_called
 
 
-# Additional Unit Tests for 100% Coverage of treeherder/services/pulse/consumers.py
-
-
 class DummyPulseConsumer(PulseConsumer):
     queue_suffix = "dummy"
 

--- a/tests/services/pulse/test_exchange.py
+++ b/tests/services/pulse/test_exchange.py
@@ -9,6 +9,7 @@ from .utils import create_and_destroy_exchange
 
 @pytest.mark.skipif(IS_WINDOWS, reason="celery does not work on windows")
 def test_get_existing_exchange(pulse_connection):
+    """Test retrieving an already existing exchange from the connection."""
     with create_and_destroy_exchange(pulse_connection, "foobar"):
         # shouldn't throw an error about a non-existant connection
         get_exchange(pulse_connection, "foobar")
@@ -21,3 +22,11 @@ def test_get_new_exchange(pulse_connection):
 
     assert isinstance(exchange, Exchange)
     assert exchange.name == "new_exchange"
+
+
+def test_get_non_existent_exchange_fails(pulse_connection):
+    """Test that declaring a non-existent exchange with create=False fails."""
+    # Since passive=True is set when create=False, get_exchange should raise an exception
+    # when trying to declare an exchange that has not been created.
+    with pytest.raises(Exception):
+        get_exchange(pulse_connection, "non_existent_exchange", create=False)

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -1,4 +1,6 @@
+import logging
 import pytest
+from unittest.mock import MagicMock
 
 from tests.conftest import SampleDataJSONLoader
 from treeherder.services.taskcluster import (
@@ -15,21 +17,25 @@ load_json_fixture = SampleDataJSONLoader("sherlock")
 
 @pytest.fixture(scope="module")
 def actions_json():
+    """Load actions json sample fixture data."""
     return load_json_fixture("initialActions.json")
 
 
 @pytest.fixture(scope="module")
 def expected_actions_json():
+    """Load expected actions json sample fixture data."""
     return load_json_fixture("reducedActions.json")
 
 
 @pytest.fixture(scope="module")
 def original_task():
+    """Load original task sample fixture data."""
     return load_json_fixture("originalTask.json")
 
 
 @pytest.fixture(scope="module")
 def expected_backfill_task():
+    """Load expected backfill task sample fixture data."""
     return load_json_fixture("backfillTask.json")
 
 
@@ -38,6 +44,7 @@ class TestTaskclusterModelImpl:
     FAKE_OPTIONS = (FAKE_ROOT_URL, "FAKE_CLIENT_ID", "FAKE_ACCESS_TOKEN")
 
     def test_can_instantiate_without_credentials(self):
+        """Test instantiation of TaskclusterModelImpl without credentials parameter."""
         try:
             _ = TaskclusterModelImpl(self.FAKE_ROOT_URL)
         except ValueError:
@@ -45,7 +52,166 @@ class TestTaskclusterModelImpl:
                 "Should be able to instantiate TaskclusterModelImpl without providing credentials."
             )
 
+    def test_can_instantiate_with_credentials(self):
+        """Test instantiation of TaskclusterModelImpl with provided client ID and access token."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL, client_id="my-client", access_token="my-token")
+        client_id_val = model.hooks.options["credentials"]["clientId"]
+        if isinstance(client_id_val, bytes):
+            client_id_val = client_id_val.decode("utf-8")
+        assert client_id_val == "my-client"
+
+        access_token_val = model.hooks.options["credentials"]["accessToken"]
+        if isinstance(access_token_val, bytes):
+            access_token_val = access_token_val.decode("utf-8")
+        assert access_token_val == "my-token"
+
+    def test_trigger_action(self, monkeypatch):
+        """Test trigger_action routes through actions loading, resolution, and submission."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+
+        # Mock _load, _get_action, and _submit
+        loaded_context = {"actions": [{"name": "backfill"}], "staticActionVariables": {}}
+        monkeypatch.setattr(model, "_load", lambda dec_id, t_id: loaded_context)
+        monkeypatch.setattr(model, "_get_action", lambda actions, name: actions[0])
+        monkeypatch.setattr(
+            model,
+            "_submit",
+            lambda action, decision_task_id, task_id, input, static_action_variables: "new-task-id",
+        )
+
+        task_id = model.trigger_action(
+            "backfill", "task123", "decision123", {"foo": "bar"}, root_url="https://newroot.org"
+        )
+        assert task_id == "new-task-id"
+        assert model.hooks.options["rootUrl"] == "https://newroot.org"
+
+    def test_load_no_decision_task_id(self):
+        """Test that _load raises ValueError if no decision task ID is supplied."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+        with pytest.raises(ValueError, match="No decision task, can't find taskcluster actions"):
+            model._load("", "task123")
+
+    def test_load_wrong_version(self, monkeypatch):
+        """Test that _load raises RuntimeError if the actions.json schema version is not supported."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+
+        # Mock buildUrl and task definition
+        monkeypatch.setattr(model.queue, "buildUrl", lambda name, *args: "https://fake-url.com")
+        monkeypatch.setattr(model.queue, "task", lambda task_id: {})
+
+        class MockResponse:
+            def json(self):
+                return {"version": 2}  # Wrong version
+
+        monkeypatch.setattr("requests.request", lambda method, url: MockResponse())
+
+        with pytest.raises(RuntimeError, match="Wrong version of actions.json, unable to continue"):
+            model._load("decision123", "task123")
+
+    def test_load_success(self, monkeypatch):
+        """Test successful loading and parsing of actions and static variables."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+
+        monkeypatch.setattr(model.queue, "buildUrl", lambda name, *args: "https://fake-url.com")
+        monkeypatch.setattr(model.queue, "task", lambda task_id: {"tags": {"kind": "test"}})
+
+        class MockResponse:
+            def json(self):
+                return {
+                    "version": 1,
+                    "variables": {"var1": "val1"},
+                    "actions": [
+                        {
+                            "name": "backfill",
+                            "context": [{"kind": "test"}],
+                        }
+                    ],
+                }
+
+        monkeypatch.setattr("requests.request", lambda method, url: MockResponse())
+
+        result = model._load("decision123", "task123")
+        assert result["staticActionVariables"] == {"var1": "val1"}
+        assert len(result["actions"]) == 1
+        assert result["actions"][0]["name"] == "backfill"
+
+    def test_submit_unsupported_kind(self):
+        """Test that submitting an action of an unsupported kind raises NotImplementedError."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+        action = {"kind": "not-hook"}
+        with pytest.raises(NotImplementedError, match="Unable to submit actions with 'not-hook' kind"):
+            model._submit(
+                action=action,
+                decision_task_id="decision123",
+                task_id="task123",
+                input={},
+                static_action_variables={},
+            )
+
+    def test_submit_hook_success(self, monkeypatch):
+        """Test successful action submission of hook kind."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+
+        action = {
+            "kind": "hook",
+            "hookPayload": {"taskGroupId": "${taskGroupId}"},
+            "hookId": "my-hook-id",
+            "hookGroupId": "my-hook-group-id",
+        }
+
+        monkeypatch.setattr(model.queue, "task", lambda task_id: {"scopes": ["scope1"]})
+        monkeypatch.setattr(
+            model.auth,
+            "expandScopes",
+            lambda req: {"scopes": ["in-tree:hook-action:my-hook-group-id/my-hook-id"]},
+        )
+
+        triggered = []
+
+        def mock_trigger(group_id, hook_id, payload):
+            triggered.append((group_id, hook_id, payload))
+            return {"status": {"taskId": "new-task-123"}}
+
+        monkeypatch.setattr(model.hooks, "triggerHook", mock_trigger)
+
+        task_id = model._submit(
+            action=action,
+            decision_task_id="decision123",
+            task_id="task123",
+            input={},
+            static_action_variables={},
+        )
+        assert task_id == "new-task-123"
+        assert len(triggered) == 1
+        assert triggered[0] == ("my-hook-group-id", "my-hook-id", {"taskGroupId": "decision123"})
+
+    def test_submit_hook_unsatisfied_scopes(self, monkeypatch):
+        """Test that submitting a hook action without satisfying scopes raises RuntimeError."""
+        model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
+
+        action = {
+            "kind": "hook",
+            "hookPayload": {},
+            "hookId": "my-hook-id",
+            "hookGroupId": "my-hook-group-id",
+        }
+
+        monkeypatch.setattr(model.queue, "task", lambda task_id: {"scopes": ["scope1"]})
+        monkeypatch.setattr(model.auth, "expandScopes", lambda req: {"scopes": ["some-other-scope"]})
+
+        with pytest.raises(
+            RuntimeError, match="Action is misconfigured: decision task's scopes do not satisfy"
+        ):
+            model._submit(
+                action=action,
+                decision_task_id="decision123",
+                task_id="task123",
+                input={},
+                static_action_variables={},
+            )
+
     def test_filter_relevant_actions(self, actions_json, original_task, expected_actions_json):
+        """Test filtering actions down to the relevant ones for a given task context."""
         reduced_actions_json = TaskclusterModelImpl._filter_relevant_actions(
             actions_json, original_task
         )
@@ -53,6 +219,7 @@ class TestTaskclusterModelImpl:
         assert reduced_actions_json == expected_actions_json
 
     def test_task_in_context(self):
+        """Test identifying if a task matches action tag-sets."""
         # match
         tag_set_list, task_tags = (
             load_json_fixture(f) for f in ("matchingTagSetList.json", "matchingTaskTags.json")
@@ -65,28 +232,70 @@ class TestTaskclusterModelImpl:
         )
         assert TaskclusterModelImpl._task_in_context(tag_set_list, task_tags) is False
 
+    def test_task_in_context_empty_or_mismatch(self):
+        """Test task matching against empty context or mismatching tags."""
+        # Empty context
+        assert TaskclusterModelImpl._task_in_context([], {"a": "b"}) is False
+        # Task with mismatching tags
+        assert TaskclusterModelImpl._task_in_context([{"a": "b"}], {"c": "d"}) is False
+
     def test_get_action(self, actions_json, expected_backfill_task):
+        """Test selecting a specific action from a list of actions by name."""
         action_array = actions_json["actions"]
 
         backfill_task = TaskclusterModelImpl._get_action(action_array, "backfill")
         assert backfill_task == expected_backfill_task
 
+    def test_get_action_lookup_error(self):
+        """Test that get_action raises LookupError when the requested action is missing."""
+        action_array = [{"name": "foo"}]
+        with pytest.raises(LookupError, match="bar action is not available for this task.  Available: foo"):
+            TaskclusterModelImpl._get_action(action_array, "bar")
+
+    def test_taskcluster_model_null_object(self):
+        """Test trigger_action on TaskclusterModelNullObject stub returns fake task ID."""
+        obj = TaskclusterModelNullObject("https://fake-root.org")
+        res = obj.trigger_action("backfill", "task123", "decision123", {})
+        assert res.startswith("fake-backfill-task-id-for-task123-")
+
+    def test_notify_null_object(self, caplog):
+        """Test NotifyNullObject stub logs email debug statements and doesn't send emails."""
+        logger = logging.getLogger("treeherder.services.taskcluster")
+        logger.setLevel(logging.DEBUG)
+        obj = NotifyNullObject()
+        with caplog.at_level(logging.DEBUG):
+            obj.email("arg1", "arg2", foo="bar")
+            assert "Faking sending of email `('arg1', 'arg2')`" in caplog.text
+
+    def test_notify_adapter(self, monkeypatch):
+        """Test NotifyAdapter calls underlying taskcluster Notify client email method."""
+        mock_notify_client = MagicMock()
+        monkeypatch.setattr("taskcluster.Notify", lambda options, session: mock_notify_client)
+
+        adapter = NotifyAdapter()
+        adapter.email("arg1", "arg2", foo="bar")
+        mock_notify_client.email.assert_called_once_with("arg1", "arg2", foo="bar")
+
 
 class TestTaskclusterModelFactory:
     def test_returns_null_object_on_non_production(self):
+        """Test taskcluster_model_factory returns stub on non-production environment."""
         notify = taskcluster_model_factory()
         assert isinstance(notify, TaskclusterModelNullObject)
 
     def test_returns_real_client_on_production(self, mock_tc_prod_backfill_credentials):
+        """Test taskcluster_model_factory returns implementation on production environment."""
         notify = taskcluster_model_factory()
         assert isinstance(notify, TaskclusterModelImpl)
 
 
 class TestNotifyClientFactory:
     def test_returns_null_object_on_non_production(self):
+        """Test notify_client_factory returns stub on non-production environment."""
         notify = notify_client_factory()
         assert isinstance(notify, NotifyNullObject)
 
     def test_returns_real_client_on_production(self, mock_tc_prod_notify_credentials):
+        """Test notify_client_factory returns NotifyAdapter on production environment."""
         notify = notify_client_factory()
         assert isinstance(notify, NotifyAdapter)

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -1,6 +1,7 @@
 import logging
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from tests.conftest import SampleDataJSONLoader
 from treeherder.services.taskcluster import (
@@ -54,7 +55,9 @@ class TestTaskclusterModelImpl:
 
     def test_can_instantiate_with_credentials(self):
         """Test instantiation of TaskclusterModelImpl with provided client ID and access token."""
-        model = TaskclusterModelImpl(self.FAKE_ROOT_URL, client_id="my-client", access_token="my-token")
+        model = TaskclusterModelImpl(
+            self.FAKE_ROOT_URL, client_id="my-client", access_token="my-token"
+        )
         client_id_val = model.hooks.options["credentials"]["clientId"]
         if isinstance(client_id_val, bytes):
             client_id_val = client_id_val.decode("utf-8")
@@ -139,7 +142,9 @@ class TestTaskclusterModelImpl:
         """Test that submitting an action of an unsupported kind raises NotImplementedError."""
         model = TaskclusterModelImpl(self.FAKE_ROOT_URL)
         action = {"kind": "not-hook"}
-        with pytest.raises(NotImplementedError, match="Unable to submit actions with 'not-hook' kind"):
+        with pytest.raises(
+            NotImplementedError, match="Unable to submit actions with 'not-hook' kind"
+        ):
             model._submit(
                 action=action,
                 decision_task_id="decision123",
@@ -197,7 +202,9 @@ class TestTaskclusterModelImpl:
         }
 
         monkeypatch.setattr(model.queue, "task", lambda task_id: {"scopes": ["scope1"]})
-        monkeypatch.setattr(model.auth, "expandScopes", lambda req: {"scopes": ["some-other-scope"]})
+        monkeypatch.setattr(
+            model.auth, "expandScopes", lambda req: {"scopes": ["some-other-scope"]}
+        )
 
         with pytest.raises(
             RuntimeError, match="Action is misconfigured: decision task's scopes do not satisfy"
@@ -249,7 +256,9 @@ class TestTaskclusterModelImpl:
     def test_get_action_lookup_error(self):
         """Test that get_action raises LookupError when the requested action is missing."""
         action_array = [{"name": "foo"}]
-        with pytest.raises(LookupError, match="bar action is not available for this task.  Available: foo"):
+        with pytest.raises(
+            LookupError, match="bar action is not available for this task.  Available: foo"
+        ):
             TaskclusterModelImpl._get_action(action_array, "bar")
 
     def test_taskcluster_model_null_object(self):

--- a/tests/services/test_taskcluster.py
+++ b/tests/services/test_taskcluster.py
@@ -18,25 +18,21 @@ load_json_fixture = SampleDataJSONLoader("sherlock")
 
 @pytest.fixture(scope="module")
 def actions_json():
-    """Load actions json sample fixture data."""
     return load_json_fixture("initialActions.json")
 
 
 @pytest.fixture(scope="module")
 def expected_actions_json():
-    """Load expected actions json sample fixture data."""
     return load_json_fixture("reducedActions.json")
 
 
 @pytest.fixture(scope="module")
 def original_task():
-    """Load original task sample fixture data."""
     return load_json_fixture("originalTask.json")
 
 
 @pytest.fixture(scope="module")
 def expected_backfill_task():
-    """Load expected backfill task sample fixture data."""
     return load_json_fixture("backfillTask.json")
 
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -48,3 +48,18 @@ DEBUG_TOOLBAR_CONFIG = {
 }
 
 INSTALLED_APPS.remove("django.contrib.staticfiles")  # noqa: F405
+
+# Use local memory cache instead of live Redis database for testing
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "unique-snowflake",
+    },
+    "db_cache": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "db_cache",
+    },
+}
+
+# Use memory transport instead of active RabbitMQ for Kombu and Celery testing
+CELERY_BROKER_URL = "memory://"


### PR DESCRIPTION
This PR adds comprehensive unit test coverage for the `treeherder/services/`  package to achieve 100% line coverage:

## Changes

**Test Files:**
- `tests/services/pulse/test_consumers.py`: Added tests covering all consumer classes (TaskConsumer, MozciClassificationConsumer, PushConsumer, JointConsumer), factory functions (prepare_consumers, prepare_joint_consumers), and edge cases like binding/unbinding queues and stale binding pruning
- `tests/services/pulse/test_exchange.py`: Added test for non-existent exchange error handling with create=False
- `tests/services/test_taskcluster.py`: Added tests covering TaskclusterModelImpl.trigger_action(), _load(), _submit(), hook submission, scope validation, and factory methods

**Configuration:**
- `tests/settings.py`: Added memory-based cache backend (LocMemCache) and in-memory Celery broker URL (memory://) to enable isolated test execution without external dependencies (Redis, RabbitMQ)

## Coverage
Achieves 100% line coverage for:
- `treeherder/services/pulse/consumers.py`
- `treeherder/services/pulse/exchange.py`
- `treeherder/services/taskcluster.py`

<img width="1127" height="663" alt="image" src="https://github.com/user-attachments/assets/b5735a48-2e71-4409-8d44-7896ee37b547" />



Fixes [Bug-2054841](https://bugzilla.mozilla.org/show_bug.cgi?id=2054841)

@gmierz @Archaeopteryx 