### PR TITLE
Bug-2038705: Migrate get_releases function to PyGithub and update tests

### DIFF
--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -2,7 +2,7 @@ import binascii
 import json
 import os
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest import mock
 
 import responses
@@ -19,7 +19,7 @@ COMMIT_INFO = re.compile(r"https://api.github.com/repos/.*/.*/commits/.*")
 
 
 def prepare_responses():
-    now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+    now = datetime.now(tz=UTC).isoformat(timespec="seconds")
 
     def _commit():
         files = [{"filename": "file1"}, {"filename": "file2"}]
@@ -53,9 +53,9 @@ def prepare_responses():
 @responses.activate
 @mock.patch("treeherder.utils.github.pygithub_get_repo")
 def test_collect(mock_pygithub_get_repo):
-    now = datetime.now()
+    now = datetime.now(tz=UTC)
     yesterday = now - timedelta(days=1)
-    yesterday_str = yesterday.strftime("%Y-%m-%dT%H:%M:%S")
+    yesterday_str = yesterday.isoformat(timespec="seconds")
 
     # Mock the GitRelease object structure expected by collector.py
     mock_author = mock.Mock()
@@ -85,7 +85,7 @@ def test_collect(mock_pygithub_get_repo):
     assert release_entry["message"] == "Released mock_release_name"
     assert release_entry["remote_id"] == "mock_release_id_123"
     assert release_entry["url"] == "mock_release_url"
-    assert release_entry["date"] == now.isoformat()
+    assert release_entry["date"] == now.isoformat(timespec="seconds")
 
     # Verify a commit entry created from responses mock
     commit_entry = next((item for item in res if item["type"] == "commit"), None)

--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from datetime import datetime, timedelta
+from unittest import mock
 
 import responses
 
@@ -13,30 +14,12 @@ def random_id():
     return binascii.hexlify(os.urandom(16)).decode("utf8")
 
 
-RELEASES = re.compile(r"https://api.github.com/repos/.*/.*/releases.*")
 COMMITS = re.compile(r"https://api.github.com/repos/.*/.*/commits\?.*")
 COMMIT_INFO = re.compile(r"https://api.github.com/repos/.*/.*/commits/.*")
 
 
 def prepare_responses():
     now = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
-
-    def releases(request):
-        data = [
-            {
-                "name": "ok",
-                "published_at": now,
-                "id": random_id(),
-                "html_url": "url",
-                "tag_name": "some tag",
-                "author": {"login": "tarek"},
-            }
-        ]
-        return 200, {}, json.dumps(data)
-
-    responses.add_callback(
-        responses.GET, RELEASES, callback=releases, content_type="application/json"
-    )
 
     def _commit():
         files = [{"filename": "file1"}, {"filename": "file2"}]
@@ -68,12 +51,44 @@ def prepare_responses():
 
 
 @responses.activate
-def test_collect():
-    yesterday = datetime.now() - timedelta(days=1)
-    yesterday = yesterday.strftime("%Y-%m-%dT%H:%M:%S")
-    prepare_responses()
-    res = list(collect(yesterday))
+@mock.patch("treeherder.utils.github.pygithub_get_repo")
+def test_collect(mock_pygithub_get_repo):
+    now = datetime.now()
+    yesterday = now - timedelta(days=1)
+    yesterday_str = yesterday.strftime("%Y-%m-%dT%H:%M:%S")
 
-    # we're not looking into much details here, we can do this
-    # once we start to tweak the filters
+    # Mock the GitRelease object structure expected by collector.py
+    mock_author = mock.Mock()
+    mock_author.login = "mock_tarek_release"
+    mock_release = mock.Mock()
+    mock_release.name = "mock_release_name"
+    mock_release.tag_name = "mock_release_tag"
+    mock_release.published_at = now
+    mock_release.id = "mock_release_id_123"
+    mock_release.html_url = "mock_release_url"
+    mock_release.author = mock_author
+
+    mock_repo = mock.Mock()
+    mock_repo.get_releases.return_value = [mock_release]
+    mock_pygithub_get_repo.return_value = mock_repo
+
+    prepare_responses()
+    res = list(collect(yesterday_str))
+
+    # Assertions to ensure both release and commit data are collected
     assert len(res) > 0
+
+    # Verify a release entry created from the mock PyGithub object
+    release_entry = next((item for item in res if item["type"] == "release"), None)
+    assert release_entry is not None
+    assert release_entry["author"] == "mock_tarek_release"
+    assert release_entry["message"] == "Released mock_release_name"
+    assert release_entry["remote_id"] == "mock_release_id_123"
+    assert release_entry["url"] == "mock_release_url"
+    assert release_entry["date"] == now.isoformat()
+
+    # Verify a commit entry created from responses mock
+    commit_entry = next((item for item in res if item["type"] == "commit"), None)
+    assert commit_entry is not None
+    assert commit_entry["author"] == "tarek"
+    assert commit_entry["message"] == "yeah"

--- a/tests/changelog/test_tasks.py
+++ b/tests/changelog/test_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest import mock
 
 import pytest
@@ -14,7 +14,7 @@ from treeherder.changelog.tasks import update_changelog
 @mock.patch("treeherder.utils.github.pygithub_get_repo")
 def test_update_changelog(mock_pygithub_get_repo):
     # Mock the GitRelease object structure expected by collector.py
-    now = datetime.now()
+    now = datetime.now(tz=UTC)
     mock_author = mock.Mock()
     mock_author.login = "mock_tarek_release"
     mock_release = mock.Mock()

--- a/tests/changelog/test_tasks.py
+++ b/tests/changelog/test_tasks.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from unittest import mock
+
 import pytest
 import responses
 
@@ -8,7 +11,24 @@ from treeherder.changelog.tasks import update_changelog
 
 @pytest.mark.django_db()
 @responses.activate
-def test_update_changelog():
+@mock.patch("treeherder.utils.github.pygithub_get_repo")
+def test_update_changelog(mock_pygithub_get_repo):
+    # Mock the GitRelease object structure expected by collector.py
+    now = datetime.now()
+    mock_author = mock.Mock()
+    mock_author.login = "mock_tarek_release"
+    mock_release = mock.Mock()
+    mock_release.name = "mock_release_name"
+    mock_release.tag_name = "mock_release_tag"
+    mock_release.published_at = now
+    mock_release.id = "mock_release_id_123"
+    mock_release.html_url = "mock_release_url"
+    mock_release.author = mock_author
+
+    mock_repo = mock.Mock()
+    mock_repo.get_releases.return_value = [mock_release]
+    mock_pygithub_get_repo.return_value = mock_repo
+
     prepare_responses()
     num_entries = Changelog.objects.count()
 
@@ -17,3 +37,6 @@ def test_update_changelog():
     # we're not looking into much details here, we can do this
     # once we start to tweak the filters
     assert Changelog.objects.count() > num_entries
+
+    # Also verify that at least one release entry was created
+    assert Changelog.objects.filter(type="release", remote_id="mock_release_id_123").exists()

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -1,0 +1,190 @@
+from datetime import datetime
+from unittest.mock import patch
+
+# Import the function to be tested
+from treeherder.utils.github import get_releases
+
+
+# Mock GitRelease class to simulate PyGithub's GitRelease objects
+class MockGitRelease:
+    def __init__(self, published_at_str, title=""):
+        # Store published_at as a datetime object
+        self.published_at = datetime.fromisoformat(published_at_str)
+        self.title = title
+
+    # Add __repr__ for better debugging output in case of test failures
+    def __repr__(self):
+        return (
+            f"<MockGitRelease title='{self.title}' published_at='{self.published_at.isoformat()}'>"
+        )
+
+    # Add __eq__ for proper comparison in assertions
+    def __eq__(self, other):
+        if not isinstance(other, MockGitRelease):
+            return NotImplemented
+        return self.published_at == other.published_at and self.title == other.title
+
+
+# Mock Repository class to simulate PyGithub's Repository objects
+class MockRepository:
+    def __init__(self, releases):
+        self._releases = releases
+
+    def get_releases(self):
+        # PyGithub's get_releases returns an iterable (PaginatedList).
+        # Returning a list directly simplifies the mock while maintaining iterable behavior.
+        return self._releases
+
+
+@patch("treeherder.utils.github.github")
+def test_get_releases_no_params(mock_github):
+    """
+    Test get_releases reruns all releases when no filtering parameters are provided.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    # Define mock release objects
+    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
+    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
+    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
+    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+
+    # Configure the mock github object to return our mock repository
+    mock_repo_instance = MockRepository(all_mock_releases)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    # Call the function under test without any params
+    result = get_releases(owner, repo)
+
+    # Assertions
+    # Ensure get_repo was called correctly
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    # Ensure all releases are returned
+    assert len(result) == 3
+    assert result == all_mock_releases
+
+
+@patch("treeherder.utils.github.github")
+def test_get_releases_with_number_param(mock_github):
+    """
+    Test get_releases returns the oldest N items per repository when filtered by the 'number' parameter.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
+    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
+    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
+    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+
+    mock_repo_instance = MockRepository(all_mock_releases)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    # Test with number = 2
+    params = {"number": 2}
+    result = get_releases(owner, repo, params)
+
+    assert len(result) == 2
+    assert result == [mock_release_1, mock_release_2]
+
+    # Test with number larger than available releases
+    params_large_number = {"number": 10}
+    result_large_number = get_releases(owner, repo, params_large_number)
+    assert len(result_large_number) == 3
+    assert result_large_number == all_mock_releases
+
+
+@patch("treeherder.utils.github.github")
+def test_get_releases_with_since_param(mock_github):
+    """
+    Test get_releases returns relases published after the 'since' parameter when provided with a 'since' parameter.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
+    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
+    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
+    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+
+    mock_repo_instance = MockRepository(all_mock_releases)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    # Test with a 'since' date that includes Release 2 and 3
+    since_date_str = "2023-01-05T12:00:00"
+    params = {"since": since_date_str}
+    result = get_releases(owner, repo, params)
+
+    assert len(result) == 2
+    assert result == [mock_release_2, mock_release_3]
+
+    # Test with a 'since' date that excludes everything
+    since_date_str_later = "2023-01-15T00:00:00"
+    params_later = {"since": since_date_str_later}
+    result_later = get_releases(owner, repo, params_later)
+    assert len(result_later) == 0
+
+    # Test with a 'since' date that includes everything
+    since_date_str_earlier = "2022-12-31T00:00:00"
+    params_earlier = {"since": since_date_str_earlier}
+    result_earlier = get_releases(owner, repo, params_earlier)
+    assert len(result_earlier) == 3
+    assert result_earlier == all_mock_releases
+
+
+@patch("treeherder.utils.github.github")
+def test_get_releases_with_number_and_since_params(mock_github):
+    """
+    Test get_releases orders releases correctly when filtered by both 'number' and 'since' parameters.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
+    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
+    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
+    mock_release_4 = MockGitRelease("2023-01-15T16:00:00", "Release 4")
+    mock_release_5 = MockGitRelease("2023-01-20T18:00:00", "Release 5")
+    all_mock_releases = [
+        mock_release_1,
+        mock_release_2,
+        mock_release_3,
+        mock_release_4,
+        mock_release_5,
+    ]
+
+    mock_repo_instance = MockRepository(all_mock_releases)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    # Scenario 1: number=2, since='2023-01-05T12:00:00'
+    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:2] -> [R1, R2]
+    # 2. Apply since filter to [R1, R2]:
+    #    R1 (Jan 1) is NOT >= Jan 5
+    #    R2 (Jan 5) IS >= Jan 5
+    # Expected: [R2]
+    params_s1 = {"since": "2023-01-05T12:00:00", "number": 2}
+    result_s1 = get_releases(owner, repo, params_s1)
+    assert len(result_s1) == 1
+    assert result_s1 == [mock_release_2]
+
+    # Scenario 2: number=1, since='2023-01-10T14:00:00'
+    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:1] -> [R1]
+    # 2. Apply since filter to [R1]:
+    #    R1 (Jan 1) is NOT >= Jan 10
+    # Expected: []
+    params_s2 = {"since": "2023-01-10T14:00:00", "number": 1}
+    result_s2 = get_releases(owner, repo, params_s2)
+    assert len(result_s2) == 0
+    assert result_s2 == []
+
+    # Scenario 3: number=100 (effectively no number limit), since='2023-01-10T14:00:00'
+    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:100] -> [R1, R2, R3, R4, R5]
+    # 2. Apply since filter to [R1, R2, R3, R4, R5]:
+    #    R1, R2 are NOT >= Jan 10
+    #    R3, R4, R5 ARE >= Jan 10
+    # Expected: [R3, R4, R5]
+    params_s3 = {"since": "2023-01-10T14:00:00", "number": 100}
+    result_s3 = get_releases(owner, repo, params_s3)
+    assert len(result_s3) == 3
+    assert result_s3 == [mock_release_3, mock_release_4, mock_release_5]

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -1,28 +1,64 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 # Import the function to be tested
 from treeherder.utils.github import get_releases
 
 
+# Helper for MockGitRelease
+class MockAuthor:
+    def __init__(self, login):
+        self.login = login
+
+    def __repr__(self):
+        return f"<MockAuthor login='{self.login}'>"
+
+
 # Mock GitRelease class to simulate PyGithub's GitRelease objects
 class MockGitRelease:
-    def __init__(self, published_at_str, title=""):
-        # Store published_at as a datetime object
-        self.published_at = datetime.fromisoformat(published_at_str)
+    def __init__(
+        self,
+        published_at_str,
+        title="",
+        id=None,
+        tag_name=None,
+        html_url=None,
+        author_login="test-author",
+    ):
+        # Store published_at as a datetime object, ensuring it's timezone-aware
+        dt_obj = datetime.fromisoformat(published_at_str)
+        self.published_at = dt_obj.replace(tzinfo=UTC) if dt_obj.tzinfo is None else dt_obj
+
         self.title = title
+        # Simulate other attributes expected by get_releases
+        # Using hash for default ID to provide some uniqueness if not explicitly set
+        self.id = id if id is not None else hash(published_at_str + title) % (10**7)
+        self.name = title if title else f"Release {self.id}"
+        self.tag_name = tag_name if tag_name is not None else f"v{self.id}"
+        self.html_url = (
+            html_url
+            if html_url is not None
+            else f"https://github.com/mock-owner/mock-repo/releases/tag/{self.tag_name}"
+        )
+        self.author = MockAuthor(author_login) if author_login else None
+
+    # This method creates the dictionary structure that get_releases in github.py is expected to return
+    def to_expected_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "tag_name": self.tag_name,
+            "published_at": self.published_at,
+            "html_url": self.html_url,
+            "author": {"login": self.author.login if self.author else "unknown"},
+        }
 
     # Add __repr__ for better debugging output in case of test failures
     def __repr__(self):
         return (
-            f"<MockGitRelease title='{self.title}' published_at='{self.published_at.isoformat()}'>"
+            f"<MockGitRelease id={self.id}, name='{self.name}', tag_name='{self.tag_name}', "
+            f"published_at='{self.published_at.isoformat()}', author={self.author}>"
         )
-
-    # Add __eq__ for proper comparison in assertions
-    def __eq__(self, other):
-        if not isinstance(other, MockGitRelease):
-            return NotImplemented
-        return self.published_at == other.published_at and self.title == other.title
 
 
 # Mock Repository class to simulate PyGithub's Repository objects
@@ -31,8 +67,9 @@ class MockRepository:
         self._releases = releases
 
     def get_releases(self):
-        # PyGithub's get_releases returns an iterable (PaginatedList).
-        # Returning a list directly simplifies the mock while maintaining iterable behavior.
+        # PyGithub's get_releases returns an iterable (PaginatedList),
+        # with releases in reverse chronological order.
+        # Returning a list directly simulates this behavior for the mock.
         return self._releases
 
 
@@ -44,25 +81,29 @@ def test_get_releases_no_params(mock_github):
     owner = "test-owner"
     repo = "test-repo"
 
-    # Define mock release objects
-    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
-    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
-    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
-    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+    # Define mock release objects in chronological order
+    mock_release_1_input = MockGitRelease("2023-01-01T10:00:00+00:00", "Release 1", id=101)
+    mock_release_2_input = MockGitRelease("2023-01-05T12:00:00+00:00", "Release 2", id=102)
+    mock_release_3_input = MockGitRelease("2023-01-10T14:00:00+00:00", "Release 3", id=103)
+    all_mock_releases_chrono = [mock_release_1_input, mock_release_2_input, mock_release_3_input]
+
+    # For MockRepository, simulate PyGithub's reverse chronological order
+    all_mock_releases_input_for_repo = list(reversed(all_mock_releases_chrono))
 
     # Configure the mock github object to return our mock repository
-    mock_repo_instance = MockRepository(all_mock_releases)
+    mock_repo_instance = MockRepository(all_mock_releases_input_for_repo)
     mock_github.get_repo.return_value = mock_repo_instance
 
     # Call the function under test without any params
     result = get_releases(owner, repo)
 
+    # Construct the expected output list of dictionaries (should be in the order they were processed)
+    expected_result = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
+
     # Assertions
-    # Ensure get_repo was called correctly
     mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
-    # Ensure all releases are returned
     assert len(result) == 3
-    assert result == all_mock_releases
+    assert result == expected_result
 
 
 @patch("treeherder.utils.github.github")
@@ -73,26 +114,38 @@ def test_get_releases_with_number_param(mock_github):
     owner = "test-owner"
     repo = "test-repo"
 
-    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
-    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
-    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
-    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+    # Define mock release objects in chronological order
+    mock_release_1_input = MockGitRelease("2023-01-01T10:00:00+00:00", "Release 1", id=101)
+    mock_release_2_input = MockGitRelease("2023-01-05T12:00:00+00:00", "Release 2", id=102)
+    mock_release_3_input = MockGitRelease("2023-01-10T14:00:00+00:00", "Release 3", id=103)
+    all_mock_releases_chrono = [mock_release_1_input, mock_release_2_input, mock_release_3_input]
 
-    mock_repo_instance = MockRepository(all_mock_releases)
+    # For MockRepository, simulate PyGithub's reverse chronological order
+    all_mock_releases_input_for_repo = list(reversed(all_mock_releases_chrono))  # [R3, R2, R1]
+
+    mock_repo_instance = MockRepository(all_mock_releases_input_for_repo)
     mock_github.get_repo.return_value = mock_repo_instance
 
     # Test with number = 2
+    # get_releases processes [R3, R2, R1]
+    # It adds R3, then R2. max_number is 2, so it breaks after R2.
+    # Result should be [R3_dict, R2_dict]
     params = {"number": 2}
     result = get_releases(owner, repo, params)
 
+    expected_result_2 = [r.to_expected_dict() for r in all_mock_releases_input_for_repo[:2]]
     assert len(result) == 2
-    assert result == [mock_release_1, mock_release_2]
+    assert result == expected_result_2
 
     # Test with number larger than available releases
+    # get_releases processes [R3, R2, R1]
+    # All are added, as number limit is 10.
+    # Result should be [R3_dict, R2_dict, R1_dict]
     params_large_number = {"number": 10}
     result_large_number = get_releases(owner, repo, params_large_number)
+    expected_result_large = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
     assert len(result_large_number) == 3
-    assert result_large_number == all_mock_releases
+    assert result_large_number == expected_result_large
 
 
 @patch("treeherder.utils.github.github")
@@ -103,34 +156,58 @@ def test_get_releases_with_since_param(mock_github):
     owner = "test-owner"
     repo = "test-repo"
 
-    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
-    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
-    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
-    all_mock_releases = [mock_release_1, mock_release_2, mock_release_3]
+    # Define mock release objects in chronological order
+    mock_release_1_input = MockGitRelease("2023-01-01T10:00:00+00:00", "Release 1", id=101)
+    mock_release_2_input = MockGitRelease("2023-01-05T12:00:00+00:00", "Release 2", id=102)
+    mock_release_3_input = MockGitRelease("2023-01-10T14:00:00+00:00", "Release 3", id=103)
+    all_mock_releases_chrono = [mock_release_1_input, mock_release_2_input, mock_release_3_input]
 
-    mock_repo_instance = MockRepository(all_mock_releases)
+    # For MockRepository, simulate PyGithub's reverse chronological order
+    all_mock_releases_input_for_repo = list(reversed(all_mock_releases_chrono))  # [R3, R2, R1]
+
+    mock_repo_instance = MockRepository(all_mock_releases_input_for_repo)
     mock_github.get_repo.return_value = mock_repo_instance
 
     # Test with a 'since' date that includes Release 2 and 3
-    since_date_str = "2023-01-05T12:00:00"
+    # github.py processes [R3, R2, R1]
+    # since_dt = 2023-01-05T12:00:00+00:00 (R2's timestamp)
+    # R3 (2023-01-10) >= since_dt (add R3)
+    # R2 (2023-01-05) >= since_dt (add R2)
+    # R1 (2023-01-01) < since_dt (break)
+    # Result: [R3_dict, R2_dict]
+    since_date_str = "2023-01-05T12:00:00+00:00"
     params = {"since": since_date_str}
     result = get_releases(owner, repo, params)
 
+    expected_result = [
+        mock_release_3_input.to_expected_dict(),
+        mock_release_2_input.to_expected_dict(),
+    ]
     assert len(result) == 2
-    assert result == [mock_release_2, mock_release_3]
+    assert result == expected_result
 
     # Test with a 'since' date that excludes everything
-    since_date_str_later = "2023-01-15T00:00:00"
+    # since_dt = 2023-01-15T00:00:00+00:00
+    # R3 (2023-01-10) < since_dt (break)
+    # Result: []
+    since_date_str_later = "2023-01-15T00:00:00+00:00"
     params_later = {"since": since_date_str_later}
     result_later = get_releases(owner, repo, params_later)
     assert len(result_later) == 0
+    assert result_later == []
 
     # Test with a 'since' date that includes everything
-    since_date_str_earlier = "2022-12-31T00:00:00"
+    # since_dt = 2022-12-31T00:00:00+00:00
+    # R3 >= since_dt (add R3)
+    # R2 >= since_dt (add R2)
+    # R1 >= since_dt (add R1)
+    # Result: [R3_dict, R2_dict, R1_dict]
+    since_date_str_earlier = "2022-12-31T00:00:00+00:00"
     params_earlier = {"since": since_date_str_earlier}
     result_earlier = get_releases(owner, repo, params_earlier)
+    expected_result_earlier = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
     assert len(result_earlier) == 3
-    assert result_earlier == all_mock_releases
+    assert result_earlier == expected_result_earlier
 
 
 @patch("treeherder.utils.github.github")
@@ -141,42 +218,78 @@ def test_get_releases_with_number_and_since_params(mock_github):
     owner = "test-owner"
     repo = "test-repo"
 
-    mock_release_1 = MockGitRelease("2023-01-01T10:00:00", "Release 1")
-    mock_release_2 = MockGitRelease("2023-01-05T12:00:00", "Release 2")
-    mock_release_3 = MockGitRelease("2023-01-10T14:00:00", "Release 3")
-    mock_release_4 = MockGitRelease("2023-01-15T16:00:00", "Release 4")
-    mock_release_5 = MockGitRelease("2023-01-20T18:00:00", "Release 5")
-    all_mock_releases = [
-        mock_release_1,
-        mock_release_2,
-        mock_release_3,
-        mock_release_4,
-        mock_release_5,
+    # Define mock release objects in chronological order
+    _mock_release_1_input = MockGitRelease("2023-01-01T10:00:00+00:00", "Release 1", id=101)
+    _mock_release_2_input = MockGitRelease("2023-01-05T12:00:00+00:00", "Release 2", id=102)
+    _mock_release_3_input = MockGitRelease("2023-01-10T14:00:00+00:00", "Release 3", id=103)
+    _mock_release_4_input = MockGitRelease("2023-01-15T16:00:00+00:00", "Release 4", id=104)
+    _mock_release_5_input = MockGitRelease("2023-01-20T18:00:00+00:00", "Release 5", id=105)
+
+    all_mock_releases_chrono = [
+        _mock_release_1_input,
+        _mock_release_2_input,
+        _mock_release_3_input,
+        _mock_release_4_input,
+        _mock_release_5_input,
     ]
 
-    mock_repo_instance = MockRepository(all_mock_releases)
+    # For MockRepository, simulate PyGithub's reverse chronological order
+    all_mock_releases_input_for_repo = list(
+        reversed(all_mock_releases_chrono)
+    )  # [R5, R4, R3, R2, R1]
+
+    mock_repo_instance = MockRepository(all_mock_releases_input_for_repo)
     mock_github.get_repo.return_value = mock_repo_instance
 
-    # Scenario 1: number=2, since='2023-01-05T12:00:00'
-    # Apply since filter first and then slice by number
-    # Expected: [R2, R3, R4]
-    params_s1 = {"since": "2023-01-05T12:00:00", "number": 3}
+    # Scenario 1: number=3, since='2023-01-05T12:00:00+00:00'
+    # 'since' datetime is 2023-01-05T12:00:00+00:00 (R2's timestamp)
+    # Loop over [R5, R4, R3, R2, R1]:
+    #   R5 (2023-01-20) >= since_dt (add R5) -> releases=[R5]
+    #   R4 (2023-01-15) >= since_dt (add R4) -> releases=[R5, R4]
+    #   R3 (2023-01-10) >= since_dt (add R3) -> releases=[R5, R4, R3]
+    #   R2 (2023-01-05) >= since_dt (add R2) -> releases=[R5, R4, R3, R2]
+    #   R1 (2023-01-01) < since_dt (break)
+    # Filtered by since: [R5, R4, R3, R2]
+    # Then apply 'number': take first 3 from this list.
+    # Expected: [R5_dict, R4_dict, R3_dict]
+    params_s1 = {"since": "2023-01-05T12:00:00+00:00", "number": 3}
     result_s1 = get_releases(owner, repo, params_s1)
+    expected_s1 = [
+        _mock_release_5_input.to_expected_dict(),
+        _mock_release_4_input.to_expected_dict(),
+        _mock_release_3_input.to_expected_dict(),
+    ]
     assert len(result_s1) == 3
-    assert result_s1 == [mock_release_2, mock_release_3, mock_release_4]
+    assert result_s1 == expected_s1
 
-    # Scenario 2: number=1, since='2023-01-21T14:00:00'
-    # The since filter will be applied first leaving the number filter to act on on an empty array
+    # Scenario 2: number=1, since='2023-01-20T18:00:01+00:00'
+    # 'since' datetime is 2023-01-20T18:00:01+00:00 (strictly after R5)
+    # Loop over [R5, R4, R3, R2, R1]:
+    #   R5 (2023-01-20) < since_dt (break immediately)
+    # Filtered by since: []
+    # Then apply 'number' (1):
     # Expected: []
-    params_s2 = {"since": "2023-01-20T18:00:01", "number": 1}
+    params_s2 = {"since": "2023-01-20T18:00:01+00:00", "number": 1}
     result_s2 = get_releases(owner, repo, params_s2)
     assert len(result_s2) == 0
     assert result_s2 == []
 
-    # Scenario 3: number=100 (effectively no number limit), since='2023-01-10T14:00:00'
-    # Return matches by since as the number limit is ver large
-    # Expected: [R3, R4, R5]
-    params_s3 = {"since": "2023-01-10T14:00:00", "number": 100}
+    # Scenario 3: number=100 (effectively no number limit), since='2023-01-10T14:00:00+00:00'
+    # 'since' datetime is 2023-01-10T14:00:00+00:00 (R3's timestamp)
+    # Loop over [R5, R4, R3, R2, R1]:
+    #   R5 (2023-01-20) >= since_dt (add R5)
+    #   R4 (2023-01-15) >= since_dt (add R4)
+    #   R3 (2023-01-10) >= since_dt (add R3)
+    #   R2 (2023-01-05) < since_dt (break)
+    # Filtered by since: [R5, R4, R3]
+    # Then apply 'number' (100):
+    # Expected: [R5_dict, R4_dict, R3_dict]
+    params_s3 = {"since": "2023-01-10T14:00:00+00:00", "number": 100}
     result_s3 = get_releases(owner, repo, params_s3)
+    expected_s3 = [
+        _mock_release_5_input.to_expected_dict(),
+        _mock_release_4_input.to_expected_dict(),
+        _mock_release_3_input.to_expected_dict(),
+    ]
     assert len(result_s3) == 3
-    assert result_s3 == [mock_release_3, mock_release_4, mock_release_5]
+    assert result_s3 == expected_s3

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -158,31 +158,23 @@ def test_get_releases_with_number_and_since_params(mock_github):
     mock_github.get_repo.return_value = mock_repo_instance
 
     # Scenario 1: number=2, since='2023-01-05T12:00:00'
-    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:2] -> [R1, R2]
-    # 2. Apply since filter to [R1, R2]:
-    #    R1 (Jan 1) is NOT >= Jan 5
-    #    R2 (Jan 5) IS >= Jan 5
-    # Expected: [R2]
-    params_s1 = {"since": "2023-01-05T12:00:00", "number": 2}
+    # Apply since filter first and then slice by number
+    # Expected: [R2, R3, R4]
+    params_s1 = {"since": "2023-01-05T12:00:00", "number": 3}
     result_s1 = get_releases(owner, repo, params_s1)
-    assert len(result_s1) == 1
-    assert result_s1 == [mock_release_2]
+    assert len(result_s1) == 3
+    assert result_s1 == [mock_release_2, mock_release_3, mock_release_4]
 
-    # Scenario 2: number=1, since='2023-01-10T14:00:00'
-    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:1] -> [R1]
-    # 2. Apply since filter to [R1]:
-    #    R1 (Jan 1) is NOT >= Jan 10
+    # Scenario 2: number=1, since='2023-01-21T14:00:00'
+    # The since filter will be applied first leaving the number filter to act on on an empty array
     # Expected: []
-    params_s2 = {"since": "2023-01-10T14:00:00", "number": 1}
+    params_s2 = {"since": "2023-01-20T18:00:01", "number": 1}
     result_s2 = get_releases(owner, repo, params_s2)
     assert len(result_s2) == 0
     assert result_s2 == []
 
     # Scenario 3: number=100 (effectively no number limit), since='2023-01-10T14:00:00'
-    # 1. Apply number filter first: [R1, R2, R3, R4, R5] -> [:100] -> [R1, R2, R3, R4, R5]
-    # 2. Apply since filter to [R1, R2, R3, R4, R5]:
-    #    R1, R2 are NOT >= Jan 10
-    #    R3, R4, R5 ARE >= Jan 10
+    # Return matches by since as the number limit is ver large
     # Expected: [R3, R4, R5]
     params_s3 = {"since": "2023-01-10T14:00:00", "number": 100}
     result_s3 = get_releases(owner, repo, params_s3)

--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -28,7 +28,7 @@ class GitHub:
         for release in github.get_releases(owner, repository, params=gh_options):
             name = release.name or release.tag_name
             yield {
-                "date": release.published_at.isoformat(),
+                "date": release.published_at.isoformat(timespec="seconds"),
                 "author": release.author.login,
                 "message": "Released " + name,
                 "remote_id": release.id,

--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from datetime import UTC, datetime
 
 from treeherder.changelog.filters import Filters
 from treeherder.utils import github
@@ -26,14 +27,18 @@ class GitHub:
             gh_options["since"] = kw["since"]
 
         for release in github.get_releases(owner, repository, params=gh_options):
-            name = release.name or release.tag_name
+            name = release["name"] or release["tag_name"]
+            pub_date: datetime = release["published_at"]
+            if pub_date.tzinfo is None:
+                pub_date = pub_date.replace(tzinfo=UTC)
+
             yield {
-                "date": release.published_at.isoformat(timespec="seconds"),
-                "author": release.author.login,
+                "date": pub_date.isoformat(timespec="seconds"),
+                "author": release["author"]["login"],
                 "message": "Released " + name,
-                "remote_id": release.id,
+                "remote_id": release["id"],
                 "type": "release",
-                "url": release.html_url,
+                "url": release["html_url"],
             }
 
         for commit in github.get_all_commits(owner, repository, params=gh_options):

--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -22,24 +22,19 @@ class GitHub:
         repository = kw["repository"]
         filters = kw.get("filters")
         gh_options = {"number": kw.get("number", MAX_ITEMS)}
-
-        for release in github.get_releases(owner, repository, params=gh_options):
-            release["files"] = []
-            # no "since" option for releases() we filter manually here
-            if "since" in kw and release["published_at"] <= kw["since"]:
-                continue
-            name = release["name"] or release["tag_name"]
-            yield {
-                "date": release["published_at"],
-                "author": release["author"]["login"],
-                "message": "Released " + name,
-                "remote_id": release["id"],
-                "type": "release",
-                "url": release["html_url"],
-            }
-
         if "since" in kw:
             gh_options["since"] = kw["since"]
+
+        for release in github.get_releases(owner, repository, params=gh_options):
+            name = release.name or release.tag_name
+            yield {
+                "date": release.published_at.isoformat(),
+                "author": release.author.login,
+                "message": "Released " + name,
+                "remote_id": release.id,
+                "type": "release",
+                "url": release.html_url,
+            }
 
         for commit in github.get_all_commits(owner, repository, params=gh_options):
             if filters:

--- a/treeherder/changelog/tasks.py
+++ b/treeherder/changelog/tasks.py
@@ -16,7 +16,7 @@ def update_changelog(days=1):
     logger.info(f"Updating unified changelog (days={days})")
     # collecting last day of changes across all sources
     since = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=days)
-    since = since.strftime("%Y-%m-%dT%H:%M:%S%:z")
+    since = since.isoformat(timespec="seconds")
 
     created = 0
     existed = 0
@@ -24,9 +24,6 @@ def update_changelog(days=1):
     with transaction.atomic():
         for entry in collect(since):
             files = entry.pop("files", [])
-            # lame hack to remove TZ awareness
-            if entry["date"].endswith("Z"):
-                entry["date"] = entry["date"][:-1]
             changelog, line_created = Changelog.objects.update_or_create(**entry)
             if not line_created:
                 existed += 1

--- a/treeherder/changelog/tasks.py
+++ b/treeherder/changelog/tasks.py
@@ -15,8 +15,8 @@ def update_changelog(days=1):
     """
     logger.info(f"Updating unified changelog (days={days})")
     # collecting last day of changes across all sources
-    since = datetime.datetime.now() - datetime.timedelta(days=days)
-    since = since.strftime("%Y-%m-%dT%H:%M:%S")
+    since = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=days)
+    since = since.strftime("%Y-%m-%dT%H:%M:%S %z")
 
     created = 0
     existed = 0

--- a/treeherder/changelog/tasks.py
+++ b/treeherder/changelog/tasks.py
@@ -16,7 +16,7 @@ def update_changelog(days=1):
     logger.info(f"Updating unified changelog (days={days})")
     # collecting last day of changes across all sources
     since = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(days=days)
-    since = since.strftime("%Y-%m-%dT%H:%M:%S %z")
+    since = since.strftime("%Y-%m-%dT%H:%M:%S%:z")
 
     created = 0
     existed = 0

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime
 
 from github import Auth, Github
 from github.GitRelease import GitRelease
-from github.Repository import Repository
 
 from treeherder.config.settings import GITHUB_TOKEN
 from treeherder.utils.http import fetch_json
@@ -30,11 +29,11 @@ def get_repo(owner, repo, params=None):
     return fetch_api(f"{owner}/{repo}", params)
 
 
-def pygithub_get_repo(owner, repo) -> Repository:
+def pygithub_get_repo(owner, repo):
     return github.get_repo(f"{owner}/{repo}")
 
 
-def get_releases(owner: str, repo: str, params: dict = None) -> list[dict]:
+def get_releases(owner, repo, params=None):
     """
     Retrieve GitHub releases for a given repository.
     Returns a list of standardized dictionaries representing releases.

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -34,24 +34,10 @@ def pygithub_get_repo(owner, repo) -> Repository:
     return github.get_repo(f"{owner}/{repo}")
 
 
-def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]:
+def get_releases(owner: str, repo: str, params: dict = None) -> list[dict]:
     """
     Retrieve GitHub releases for a given repository.
-
-    Args:
-        owner (str): The owner of the repository (e.g., 'mozilla').
-        repo (str): The name of the repository (e.g., 'treeherder').
-        params (dict, optional): A dictionary of parameters to filter releases.
-            Supported parameters:
-            - "number" (int): The maximum number of releases to return.
-            - "since" (str): An ISO 8601 formatted datetime string
-                             (e.g., "YYYY-MM-DDTHH:MM:SS") to filter releases
-                             published on or after this date.
-
-    Returns:
-        list[GitRelease]: A list of GitRelease objects, filtered by the given parameters.
-                          Releases are ordered from oldest to newest by published_at,
-                          then by number if applicable.
+    Returns a list of standardized dictionaries representing releases.
     """
     paginated_releases = pygithub_get_repo(owner=owner, repo=repo).get_releases()
 
@@ -80,7 +66,15 @@ def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]
                 release_dt.replace(tzinfo=UTC)
             if release.published_at < since_dt:
                 break
-        releases.append(release)
+        release_dict = {
+            "id": release.id,
+            "name": release.name,
+            "tag_name": release.tag_name,
+            "published_at": release.published_at,
+            "html_url": release.html_url,
+            "author": {"login": release.author.login if release.author else "unknown"},
+        }
+        releases.append(release_dict)
 
     return releases
 

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 from github import Auth, Github
+from github.GitRelease import GitRelease
+from github.Repository import Repository
 
 from treeherder.config.settings import GITHUB_TOKEN
 from treeherder.utils.http import fetch_json
@@ -22,16 +26,48 @@ def fetch_api_full_url(url, params=None):
     return fetch_json(url, params, headers)
 
 
-def get_releases(owner, repo, params=None):
-    return fetch_api(f"repos/{owner}/{repo}/releases", params)
-
-
 def get_repo(owner, repo, params=None):
     return fetch_api(f"{owner}/{repo}", params)
 
 
-def pygithub_get_repo(owner, repo):
+def pygithub_get_repo(owner, repo) -> Repository:
     return github.get_repo(f"{owner}/{repo}")
+
+
+def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]:
+    """
+    Retrieve GitHub releases for a given repository.
+
+    Args:
+        owner (str): The owner of the repository (e.g., 'mozilla').
+        repo (str): The name of the repository (e.g., 'treeherder').
+        params (dict, optional): A dictionary of parameters to filter releases.
+            Supported parameters:
+            - "number" (int): The maximum number of releases to return.
+            - "since" (str): An ISO 8601 formatted datetime string
+                             (e.g., "YYYY-MM-DDTHH:MM:SS") to filter releases
+                             published on or after this date.
+
+    Returns:
+        list[GitRelease]: A list of GitRelease objects, filtered by the given parameters.
+                          Releases are ordered from oldest to newest by published_at,
+                          then by number if applicable.
+    """
+    releases = list(pygithub_get_repo(owner, repo).get_releases())
+
+    if params:
+        if "number" in params:
+            releases = releases[: params.get("number")]
+
+        if "since" in params:
+            since_datetime = datetime.fromisoformat(params["since"])
+            releases = list(
+                filter(
+                    lambda release: release.published_at >= since_datetime,
+                    releases,
+                )
+            )
+    return releases
 
 
 def compare_shas(owner, repo, base, head):

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -56,9 +56,6 @@ def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]
     releases = list(pygithub_get_repo(owner, repo).get_releases())
 
     if params:
-        if "number" in params:
-            releases = releases[: params.get("number")]
-
         if "since" in params:
             since_datetime = datetime.fromisoformat(params["since"])
             releases = list(
@@ -67,6 +64,8 @@ def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]
                     releases,
                 )
             )
+        if "number" in params:
+            releases = releases[: params.get("number")]
     return releases
 
 

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from github import Auth, Github
 from github.GitRelease import GitRelease
@@ -53,19 +53,35 @@ def get_releases(owner: str, repo: str, params: dict = None) -> list[GitRelease]
                           Releases are ordered from oldest to newest by published_at,
                           then by number if applicable.
     """
-    releases = list(pygithub_get_repo(owner, repo).get_releases())
+    paginated_releases = pygithub_get_repo(owner=owner, repo=repo).get_releases()
+
+    releases: list[GitRelease] = []
+    since_dt = None
+    max_number = None
 
     if params:
-        if "since" in params:
-            since_datetime = datetime.fromisoformat(params["since"])
-            releases = list(
-                filter(
-                    lambda release: release.published_at >= since_datetime,
-                    releases,
-                )
-            )
-        if "number" in params:
-            releases = releases[: params.get("number")]
+        max_number = params.get("number")
+        since_dt = params.get("since", None)
+        if since_dt:
+            since_dt = datetime.fromisoformat(since_dt)
+            if since_dt.tzinfo is None:
+                since_dt.replace(tzinfo=UTC)
+
+    for release in paginated_releases:
+        # Break if we have reached max_number
+        if max_number and len(releases) >= max_number:
+            break
+
+        # PyGithub returns releases in reverse chronological order
+        # Stop immediately if releases older than the since_dt are found
+        release_dt = release.published_at
+        if since_dt and release_dt:
+            if release_dt.tzinfo is None:
+                release_dt.replace(tzinfo=UTC)
+            if release.published_at < since_dt:
+                break
+        releases.append(release)
+
     return releases
 
 


### PR DESCRIPTION
### Changes Introduced
- Replace the previous REST/JSON-based get_releases implementation with a PyGithub-based implementation that returns standardized release dictionaries (including a datetime object for published_at). 
- Update codepaths that consume releases (collector and tasks) to handle timezone-aware datetimes and ISO-formatted dates.

### Testing
-  Update existing changelog tests to mock PyGithub objects and add a new comprehensive unit test module (tests/utils/test_github.py) that exercises get_releases behavior across params (since, number). 
- Manually tested the command `time python manage.py updated_changelog --days 12`. It takes 23 seconds again 18 seconds taken by the old implementation.
```
root@00c495b4b5f8:/app# time python manage.py update_changelog --days 12
{"logging.googleapis.com/diagnostic": {"instrumentation_source": [{"name": "python", "version": "3.16.0"}]},"severity": "INFO", "logging.googleapis.com/labels": {"python_logger": "google.cloud.logging_v2.handlers.structured_log"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 151, "file": "/usr/local/lib/python3.13/site-packages/google/cloud/logging_v2/handlers/structured_log.py", "function": "emit_instrumentation_info"}, "httpRequest": {} }
{"message": "Updating unified changelog (days=12)","severity": "INFO", "logging.googleapis.com/labels": {"python_logger": "treeherder.changelog.tasks"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 16, "file": "/app/treeherder/changelog/tasks.py", "function": "update_changelog"}, "httpRequest": {} }
{"message": "Found 14 items, 0 existed and 14 where created.","severity": "INFO", "logging.googleapis.com/labels": {"python_logger": "treeherder.changelog.tasks"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 34, "file": "/app/treeherder/changelog/tasks.py", "function": "update_changelog"}, "httpRequest": {} }

real    0m23.569s
user    0m4.210s
sys     0m0.344s
```


Fixes Bug-2038705

@gmierz @Archaeopteryx 