### PR TITLE
Bug 2034152 - Integrate lower is better probe setting into telemetry alerts.

### DIFF
--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_alert.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_alert.py
@@ -27,7 +27,7 @@ class TestTelemetryAlert:
         """Test getting related alerts when none exist."""
         related_alerts = telemetry_alert_obj.get_related_alerts()
 
-        assert related_alerts.count() == 0
+        assert len(related_alerts) == 0
         # Verify it's cached
         assert telemetry_alert_obj.related_telemetry_alerts is not None
 
@@ -44,8 +44,9 @@ class TestTelemetryAlert:
 
         related_alerts = telemetry_alert_obj.get_related_alerts()
 
-        assert related_alerts.count() == 2
-        alert_ids = [alert.id for alert in related_alerts]
+        assert len(related_alerts) == 2
+        assert all(isinstance(related_alert, TelemetryAlert) for related_alert in related_alerts)
+        alert_ids = [related_alert.telemetry_alert.id for related_alert in related_alerts]
         assert alert2.id in alert_ids
         assert alert3.id in alert_ids
         assert telemetry_alert_obj.telemetry_alert.id not in alert_ids

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_alert.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_alert.py
@@ -74,6 +74,14 @@ class TestTelemetryAlert:
 
         assert first_call is second_call
 
+    def test_status(self, telemetry_alert_obj):
+        """Test the status label reflects the alert's is_regression flag."""
+        telemetry_alert_obj.telemetry_alert.is_regression = True
+        assert telemetry_alert_obj.status == "Regression"
+
+        telemetry_alert_obj.telemetry_alert.is_regression = False
+        assert telemetry_alert_obj.status == "Improvement"
+
     def test_str_representation(self, telemetry_alert_obj, test_telemetry_alert):
         """Test string representation of TelemetryAlert."""
         str_repr = str(telemetry_alert_obj)

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
@@ -299,6 +299,16 @@ class TestTelemetryBugContent:
             mock_link.assert_called_once_with(telemetry_alert_obj.telemetry_signature)
             assert "https://glam.telemetry.mozilla.org/test" in result
 
+    def test_build_probe_alert_row_includes_status(
+        self, bug_content, mock_probe, telemetry_alert_obj
+    ):
+        """Test that _build_probe_alert_row includes the improvement/regression status."""
+        telemetry_alert_obj.telemetry_alert.is_regression = True
+        assert "Regression" in bug_content._build_probe_alert_row(mock_probe, telemetry_alert_obj)
+
+        telemetry_alert_obj.telemetry_alert.is_regression = False
+        assert "Improvement" in bug_content._build_probe_alert_row(mock_probe, telemetry_alert_obj)
+
     def test_build_bug_content_calculates_date_range_correctly(
         self, bug_content, mock_probe, telemetry_alert_obj
     ):

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_bug_manager.py
@@ -285,19 +285,19 @@ class TestTelemetryBugContent:
         assert "P05:" in result
         assert "P95:" in result
 
-    def test_build_probe_alert_row_includes_glean_dictionary_link(
+    def test_build_probe_alert_row_includes_glam_dashboard_link(
         self, bug_content, mock_probe, telemetry_alert_obj
     ):
-        """Test that _build_probe_alert_row includes Glean Dictionary link."""
+        """Test that _build_probe_alert_row includes GLAM dashboard link."""
         with patch(
-            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.bug_manager.get_glean_dictionary_link"
+            "treeherder.perf.auto_perf_sheriffing.telemetry_alerting.bug_manager.get_glam_dashboard_link"
         ) as mock_link:
-            mock_link.return_value = "https://dictionary.telemetry.mozilla.org/test"
+            mock_link.return_value = "https://glam.telemetry.mozilla.org/test"
 
             result = bug_content._build_probe_alert_row(mock_probe, telemetry_alert_obj)
 
             mock_link.assert_called_once_with(telemetry_alert_obj.telemetry_signature)
-            assert "https://dictionary.telemetry.mozilla.org/test" in result
+            assert "https://glam.telemetry.mozilla.org/test" in result
 
     def test_build_bug_content_calculates_date_range_correctly(
         self, bug_content, mock_probe, telemetry_alert_obj

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
@@ -433,8 +433,9 @@ class TestTelemetryEmailContent:
             alert_id,
         )
 
-        # Should include Glean Dictionary link
-        assert "dictionary.telemetry.mozilla.org" in row
+        # Should include GLAM dashboard link
+        assert "glam.telemetry.mozilla.org" in row
+        assert "normalizationType=non_normalized" in row
 
         # Should include Treeherder links
         assert "treeherder.mozilla.org" in row

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
@@ -52,7 +52,9 @@ class TestTelemetryEmailManagerIntegration:
         # Verify the email payload
         email_payload = mock_email_func.call_args[0][0]
         assert email_payload["address"] == "test@mozilla.com"
-        assert email_payload["subject"] == "Telemetry Alert for Probe test_probe_metric"
+        assert (
+            email_payload["subject"] == "Telemetry Alert for Regression in Probe test_probe_metric"
+        )
         assert "MozDetect has detected a telemetry change" in email_payload["content"]
 
     @patch(
@@ -229,7 +231,7 @@ class TestTelemetryEmail:
         # Verify the email payload was passed
         email_payload = mock_email_func.call_args[0][0]
         assert email_payload["address"] == "test@mozilla.com"
-        assert email_payload["subject"] == "Telemetry Alert for Probe test_probe"
+        assert email_payload["subject"] == "Telemetry Alert for Regression in Probe test_probe"
         assert "MozDetect has detected a telemetry change" in email_payload["content"]
 
     def test_set_email_method(self):
@@ -253,7 +255,7 @@ class TestTelemetryEmail:
         result = telemetry_email._prepare_email("test@mozilla.com", mock_probe, telemetry_alert_obj)
 
         assert result["address"] == "test@mozilla.com"
-        assert result["subject"] == "Telemetry Alert for Probe test_probe"
+        assert result["subject"] == "Telemetry Alert for Regression in Probe test_probe"
         assert result["content"] is not None
 
 
@@ -266,7 +268,7 @@ class TestTelemetryEmailWriter:
         result = writer.prepare_email("test@mozilla.com", mock_probe, telemetry_alert_obj)
 
         assert result["address"] == "test@mozilla.com"
-        assert result["subject"] == "Telemetry Alert for Probe test_probe"
+        assert result["subject"] == "Telemetry Alert for Regression in Probe test_probe"
         assert "MozDetect has detected a telemetry change" in result["content"]
 
     def test_write_address_sets_email_address(self):
@@ -276,14 +278,19 @@ class TestTelemetryEmailWriter:
 
         assert writer._email.address == "test@mozilla.com"
 
-    def test_write_subject_includes_probe_name(self, mock_probe):
-        """Test _write_subject includes the probe name in the subject."""
+    def test_write_subject_includes_probe_name_and_status(self, mock_probe, telemetry_alert_obj):
+        """Test _write_subject includes the probe name and status in the subject."""
         mock_probe.name = "memory_total"
 
         writer = TelemetryEmailWriter()
-        writer._write_subject(mock_probe)
 
-        assert writer._email.subject == "Telemetry Alert for Probe memory_total"
+        telemetry_alert_obj.telemetry_alert.is_regression = True
+        writer._write_subject(mock_probe, telemetry_alert_obj)
+        assert writer._email.subject == "Telemetry Alert for Regression in Probe memory_total"
+
+        telemetry_alert_obj.telemetry_alert.is_regression = False
+        writer._write_subject(mock_probe, telemetry_alert_obj)
+        assert writer._email.subject == "Telemetry Alert for Improvement in Probe memory_total"
 
     def test_write_content_sets_email_content(self, telemetry_alert_obj, mock_probe):
         """Test _write_content sets the email content."""
@@ -374,6 +381,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
+            telemetry_alert_obj.telemetry_alert.is_regression,
         )
 
         assert len(content._raw_content) > len(initial_content)
@@ -389,12 +397,13 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
+            telemetry_alert_obj.telemetry_alert.is_regression,
         )
 
         # Should be a markdown table row with pipes
         assert row.startswith("|")
         assert row.endswith("|")
-        assert row.count("|") == 7  # 6 columns means 7 pipes
+        assert row.count("|") == 8  # 7 columns means 8 pipes
 
         # Should include key information
         assert "Nightly" in row  # channel
@@ -414,6 +423,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
+            telemetry_alert_obj.telemetry_alert.is_regression,
         )
 
         # Should include dates in YYYY-MM-DD format
@@ -431,6 +441,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             alert_id,
+            telemetry_alert_obj.telemetry_alert.is_regression,
         )
 
         # Should include GLAM dashboard link
@@ -443,6 +454,20 @@ class TestTelemetryEmailContent:
         # Should include alert details link
         assert "gmierz.github.io/telemetry-alert-dashboard" in row
         assert f"alertId={alert_id}" in row
+
+    def test_build_table_row_includes_status(self, telemetry_alert_obj):
+        """Test _build_table_row includes the improvement/regression status."""
+        content = TelemetryEmailContent()
+        detection_range = telemetry_alert_obj.get_detection_range()
+        args = (
+            detection_range,
+            telemetry_alert_obj.telemetry_signature,
+            telemetry_alert_obj.telemetry_alert_summary,
+            telemetry_alert_obj.telemetry_alert.id,
+        )
+
+        assert "Regression" in content._build_table_row(*args, True)
+        assert "Improvement" in content._build_table_row(*args, False)
 
     def test_str_returns_raw_content(self, telemetry_alert_obj, mock_probe):
         """Test __str__ returns the raw content."""
@@ -491,11 +516,12 @@ class TestTelemetryEmailContent:
         assert "Channel" in headers
         assert "Probe" in headers
         assert "Platform" in headers
+        assert "Status" in headers
         assert "Date" in headers
         assert "Detection" in headers
         assert "Alert" in headers
         assert ":---:" in headers  # Markdown center alignment
-        assert headers.count(":---:") == 6  # 6 columns
+        assert headers.count(":---:") == 7  # 7 columns
 
     def test_additional_probes_constant(self):
         """Test that ADDITIONAL_PROBES constant is properly defined."""

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_email_manager.py
@@ -381,7 +381,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
-            telemetry_alert_obj.telemetry_alert.is_regression,
+            telemetry_alert_obj.status,
         )
 
         assert len(content._raw_content) > len(initial_content)
@@ -397,7 +397,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
-            telemetry_alert_obj.telemetry_alert.is_regression,
+            telemetry_alert_obj.status,
         )
 
         # Should be a markdown table row with pipes
@@ -423,7 +423,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             telemetry_alert_obj.telemetry_alert.id,
-            telemetry_alert_obj.telemetry_alert.is_regression,
+            telemetry_alert_obj.status,
         )
 
         # Should include dates in YYYY-MM-DD format
@@ -441,7 +441,7 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_signature,
             telemetry_alert_obj.telemetry_alert_summary,
             alert_id,
-            telemetry_alert_obj.telemetry_alert.is_regression,
+            telemetry_alert_obj.status,
         )
 
         # Should include GLAM dashboard link
@@ -466,8 +466,8 @@ class TestTelemetryEmailContent:
             telemetry_alert_obj.telemetry_alert.id,
         )
 
-        assert "Regression" in content._build_table_row(*args, True)
-        assert "Improvement" in content._build_table_row(*args, False)
+        assert "Regression" in content._build_table_row(*args, "Regression")
+        assert "Improvement" in content._build_table_row(*args, "Improvement")
 
     def test_str_returns_raw_content(self, telemetry_alert_obj, mock_probe):
         """Test __str__ returns the raw content."""

--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_utils.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_utils.py
@@ -1,31 +1,34 @@
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
-    get_glean_dictionary_link,
+    get_glam_dashboard_link,
     get_treeherder_detection_link,
     get_treeherder_detection_range_link,
 )
 
 
-class TestGetGleanDictionaryLink:
+class TestGetGlamDashboardLink:
     def test_desktop_platform_windows(self, test_telemetry_signature):
-        """Test Glean dictionary link generation for Windows platform."""
+        """Test GLAM dashboard link generation for Windows platform."""
         test_telemetry_signature.platform = "Windows"
         test_telemetry_signature.probe = "test_probe"
 
-        link = get_glean_dictionary_link(test_telemetry_signature)
+        link = get_glam_dashboard_link(test_telemetry_signature)
 
-        assert (
-            link
-            == "https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/test_probe"
+        assert link == (
+            "https://glam.telemetry.mozilla.org/fog/probe/test_probe/explore"
+            "?normalizationType=non_normalized&os=Windows"
         )
 
     def test_mobile_platform_fenix(self, test_telemetry_signature):
-        """Test Glean dictionary link generation for mobile (non-desktop) platform."""
+        """Test GLAM dashboard link generation for mobile (non-desktop) platform."""
         test_telemetry_signature.platform = "Android"
         test_telemetry_signature.probe = "mobile_probe"
 
-        link = get_glean_dictionary_link(test_telemetry_signature)
+        link = get_glam_dashboard_link(test_telemetry_signature)
 
-        assert link == "https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/mobile_probe"
+        assert link == (
+            "https://glam.telemetry.mozilla.org/fenix/probe/mobile_probe/explore"
+            "?normalizationType=non_normalized&os=Android"
+        )
 
 
 class TestGetTreeherderDetectionLink:

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -434,13 +434,13 @@ class Sherlock:
 
         if probe.lower_is_better is not None:
             if probe.lower_is_better:
-                if detection.confidence >= 0:
+                if detection.confidence <= 0:
                     return True
                 return False
             else:
                 if detection.confidence < 0:
-                    return True
-                return False
+                    return False
+                return True
 
         # When lower_is_better is not specified, assume everything is a regression
         return True

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -423,6 +423,29 @@ class Sherlock:
     def _can_run_telemetry(self):
         return not self._is_prod() or (time(22, 0) <= datetime.utcnow().time() < time(23, 0))
 
+    def _is_regression(self, detection: object, probe: TelemetryProbe):
+        # detection.confidence is a subtraction of before - after
+        # in decimal form of percentage (multiply by 100)
+        # Use it in combination with probe.lower_is_better to
+        # determine if a difference is a regression or not
+        # Default to True as a regression
+
+        # confidence being negative means a shift to the left (improvement if lowerisbetter is true)
+        # confidence being positive means a shift to the right (regression if lowerisbetter is true)
+
+        if probe.lower_is_better is not None:
+            if probe.lower_is_better:
+                if detection.confidence >= 0:
+                    return True
+                return False
+            else:
+                if detection.confidence < 0:
+                    return False
+                return True
+
+        # When lower_is_better is not specified, assume everything is a regression
+        return True
+
     def _create_detection_alert(
         self,
         detection: object,
@@ -489,7 +512,7 @@ class Sherlock:
                 summary_id=detection_summary.id,
                 series_signature=probe_signature,
                 defaults={
-                    "is_regression": True,
+                    "is_regression": self._is_regression(detection, probe),
                     "amount_pct": round(
                         (100.0 * abs(detection.new_value - detection.previous_value))
                         / float(detection.previous_value),

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -428,7 +428,6 @@ class Sherlock:
         # in decimal form of percentage (multiply by 100)
         # Use it in combination with probe.lower_is_better to
         # determine if a difference is a regression or not
-        # Default to True as a regression
 
         # confidence being negative means a shift to the left (improvement if lowerisbetter is true)
         # confidence being positive means a shift to the right (regression if lowerisbetter is true)
@@ -440,8 +439,8 @@ class Sherlock:
                 return False
             else:
                 if detection.confidence < 0:
-                    return False
-                return True
+                    return True
+                return False
 
         # When lower_is_better is not specified, assume everything is a regression
         return True

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/alert.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/alert.py
@@ -26,6 +26,11 @@ class TelemetryAlert(Alert):
             optional_detection_info if optional_detection_info is not None else {}
         )
 
+    @property
+    def status(self):
+        """Human-readable label for whether this alert is a regression."""
+        return "Regression" if self.telemetry_alert.is_regression else "Improvement"
+
     def get_related_alerts(self):
         if self.related_telemetry_alerts:
             return self.related_telemetry_alerts

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/alert.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/alert.py
@@ -35,9 +35,14 @@ class TelemetryAlert(Alert):
         if self.related_telemetry_alerts:
             return self.related_telemetry_alerts
 
-        self.related_telemetry_alerts = PerformanceTelemetryAlert.objects.filter(
+        related_rows = PerformanceTelemetryAlert.objects.filter(
             summary_id=self.telemetry_alert_summary.id
         ).exclude(id=self.telemetry_alert.id)
+
+        self.related_telemetry_alerts = [
+            TelemetryAlertFactory.construct_alert(telemetry_alert=related_row)
+            for related_row in related_rows
+        ]
 
         return self.related_telemetry_alerts
 

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
@@ -93,9 +93,9 @@ class TelemetryBugContent:
     )
 
     TABLE_HEADERS = (
-        "| **Probe** | **Platform** "
+        "| **Probe** | **Platform** | **Status** "
         "| **Previous Values** | **New Values** |\n"
-        "| :---: | :---: | :---: | :---: |\n"
+        "| :---: | :---: | :---: | :---: | :---: |\n"
     )
 
     CHANGES_DETECTED_TITLE = "### Changes Detected\n"
@@ -206,13 +206,13 @@ class TelemetryBugContent:
         values = (
             f"| **Median:** {round(prev_median, 2)}{unit} "
             f"| **Median:** {round(new_median, 2)}{unit} |\n"
-            f"| | | **P05:** {round(prev_p05, 2)}{unit} "
+            f"| | | | **P05:** {round(prev_p05, 2)}{unit} "
             f"| **P05:** {round(new_p05, 2)}{unit} |\n"
-            f"| | | **P95:** {round(prev_p95, 2)}{unit} "
+            f"| | | | **P95:** {round(prev_p95, 2)}{unit} "
             f"| **P95:** {round(new_p95, 2)}{unit} |"
         )
 
         return (
             f"| [{alert.telemetry_signature.probe}]({get_glam_dashboard_link(alert.telemetry_signature)}) "
-            f"| {alert.telemetry_signature.platform} {values} \n"
+            f"| {alert.telemetry_signature.platform} | {alert.status} {values} \n"
         )

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_manager.py
@@ -5,7 +5,7 @@ from treeherder.perf.auto_perf_sheriffing.base_bug_manager import BugManager
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
     PUSH_LOG,
     TELEMETRY_ALERT_DASHBOARD,
-    get_glean_dictionary_link,
+    get_glam_dashboard_link,
     get_treeherder_detection_link,
     get_treeherder_detection_range_link,
 )
@@ -213,6 +213,6 @@ class TelemetryBugContent:
         )
 
         return (
-            f"| [{alert.telemetry_signature.probe}]({get_glean_dictionary_link(alert.telemetry_signature)}) "
+            f"| [{alert.telemetry_signature.probe}]({get_glam_dashboard_link(alert.telemetry_signature)}) "
             f"| {alert.telemetry_signature.platform} {values} \n"
         )

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_modifier.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/bug_modifier.py
@@ -120,9 +120,10 @@ class SeeAlsoModifier:
             # Get all the related bugs, excluding those we've already done since we don't
             # want to duplicate the see_also changes
             related_bugs = [
-                related_alert.bug_number
+                related_alert.telemetry_alert.bug_number
                 for related_alert in alert.get_related_alerts()
-                if related_alert.bug_number is not None and related_alert.bug_number not in changes
+                if related_alert.telemetry_alert.bug_number is not None
+                and related_alert.telemetry_alert.bug_number not in changes
             ]
 
             if related_bugs:

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
@@ -2,7 +2,7 @@ from treeherder.perf.auto_perf_sheriffing.base_email_manager import EmailManager
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
     TELEMETRY_ALERT_DASHBOARD_ALERT,
     TELEMETRY_ALERT_DASHBOARD_SUMMARY,
-    get_glean_dictionary_link,
+    get_glam_dashboard_link,
     get_treeherder_detection_link,
     get_treeherder_detection_range_link,
 )
@@ -142,14 +142,14 @@ class TelemetryEmailContent:
         # a row. That way we can decouple the information provided to bugzilla
         # users from the alerting system.
         return (
-            "| {channel} | [{probe}]({glean_dictionary_link})&nbsp;&nbsp;&nbsp;&nbsp; | {platform} "
+            "| {channel} | [{probe}]({glam_dashboard_link})&nbsp;&nbsp;&nbsp;&nbsp; | {platform} "
             "| [{date_from} - {date_to}]({treeherder_date_link})"
             "| [{commit_hash}]({treeherder_push_link}) "
             "| [{alert_id}]({alert_details_link}) |"
         ).format(
             channel=telemetry_signature.channel,
             probe=telemetry_signature.probe,
-            glean_dictionary_link=get_glean_dictionary_link(telemetry_signature),
+            glam_dashboard_link=get_glam_dashboard_link(telemetry_signature),
             platform=telemetry_signature.platform,
             date_from=detection_range["from"].time.strftime("%Y-%m-%d"),
             date_to=detection_range["to"].time.strftime("%Y-%m-%d"),

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
@@ -41,7 +41,7 @@ class TelemetryEmail:
 class TelemetryEmailWriter(EmailWriter):
     def prepare_email(self, email, probe, alert, **kwargs):
         self._write_address(email)
-        self._write_subject(probe)
+        self._write_subject(probe, alert)
         self._write_content(probe, alert)
 
         return self.email
@@ -49,8 +49,8 @@ class TelemetryEmailWriter(EmailWriter):
     def _write_address(self, email):
         self._email.address = email
 
-    def _write_subject(self, probe):
-        self._email.subject = f"Telemetry Alert for Probe {probe.name}"
+    def _write_subject(self, probe, alert):
+        self._email.subject = f"Telemetry Alert for {alert.status} in Probe {probe.name}"
 
     def _write_content(self, probe, alert):
         content = TelemetryEmailContent()
@@ -76,9 +76,10 @@ class TelemetryEmailContent:
 
     TABLE_HEADERS = (
         f"| {format_header('Channel')} | {format_header('Probe')} | {format_header('Platform')} "
+        f"| {format_header('Status')} "
         f"| {format_header('Date Range')} | {format_header('Detection Push')} "
         f"| {format_header('Alert Details')} |\n"
-        f"| :---: | :---: | :---: | :---: | :---: | :---: |\n"
+        f"| :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
     )
 
     ADDITIONAL_PROBES = (
@@ -101,6 +102,7 @@ class TelemetryEmailContent:
             alert.telemetry_signature,
             alert.telemetry_alert_summary,
             alert.telemetry_alert.id,
+            alert.status,
         )
 
         if alert.get_related_alerts():
@@ -113,10 +115,10 @@ class TelemetryEmailContent:
             self._raw_content = self.DESCRIPTION + self.TABLE_HEADERS
 
     def _include_probe(
-        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id
+        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id, status
     ):
         new_table_row = self._build_table_row(
-            detection_range, telemetry_signature, telemetry_alert_summary, alert_id
+            detection_range, telemetry_signature, telemetry_alert_summary, alert_id, status
         )
         self._raw_content += f"{new_table_row}\n"
 
@@ -133,16 +135,18 @@ class TelemetryEmailContent:
                 related_alert.series_signature,
                 alert.telemetry_alert_summary,
                 related_alert.id,
+                related_alert.is_regression,
             )
 
     def _build_table_row(
-        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id
+        self, detection_range, telemetry_signature, telemetry_alert_summary, alert_id, status
     ) -> str:
         # TODO: Have change-detection-technique/mozdetect provide a method for building
         # a row. That way we can decouple the information provided to bugzilla
         # users from the alerting system.
         return (
             "| {channel} | [{probe}]({glam_dashboard_link})&nbsp;&nbsp;&nbsp;&nbsp; | {platform} "
+            "| {status}&nbsp;&nbsp;&nbsp;&nbsp; "
             "| [{date_from} - {date_to}]({treeherder_date_link})"
             "| [{commit_hash}]({treeherder_push_link}) "
             "| [{alert_id}]({alert_details_link}) |"
@@ -151,6 +155,7 @@ class TelemetryEmailContent:
             probe=telemetry_signature.probe,
             glam_dashboard_link=get_glam_dashboard_link(telemetry_signature),
             platform=telemetry_signature.platform,
+            status=status,
             date_from=detection_range["from"].time.strftime("%Y-%m-%d"),
             date_to=detection_range["to"].time.strftime("%Y-%m-%d"),
             commit_hash=detection_range["detection"].revision[:12],

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/email_manager.py
@@ -132,10 +132,10 @@ class TelemetryEmailContent:
         for related_alert in alert.get_related_alerts():
             self._include_probe(
                 alert.get_detection_range(),
-                related_alert.series_signature,
+                related_alert.telemetry_signature,
                 alert.telemetry_alert_summary,
-                related_alert.id,
-                related_alert.is_regression,
+                related_alert.telemetry_alert.id,
+                related_alert.status,
             )
 
     def _build_table_row(

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
@@ -78,6 +78,9 @@ class TelemetryProbe:
     def is_mobile(self):
         return self.platform == MOBILE
 
+    def lower_is_better(self):
+        return self.monitor_info.get("lower_is_better")
+
     def get_change_detection_technique(self):
         return self.monitor_info.get("change_detection_technique", DEFAULT_CHANGE_DETECTION)
 

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
@@ -1,4 +1,7 @@
-GLEAN_DICTIONARY = "https://dictionary.telemetry.mozilla.org/apps/{page}/metrics/{probe}"
+GLAM_DASHBOARD = (
+    "https://glam.telemetry.mozilla.org/{product}/probe/{probe}/explore"
+    "?normalizationType=non_normalized&os={os}"
+)
 GLEAN_PROBE_INFO = (
     "https://dictionary.telemetry.mozilla.org/data/firefox_desktop/metrics/data_{probe_name}.json"
 )
@@ -62,12 +65,16 @@ ANDROID_PROBE_ALLOWLIST = (
 )
 
 
-def get_glean_dictionary_link(telemetry_signature):
+def get_glam_dashboard_link(telemetry_signature):
     if telemetry_signature.platform in DESKTOP_PLATFORMS:
-        dictionary_page = "firefox_desktop"
+        product = "fog"
     else:
-        dictionary_page = "fenix"
-    return GLEAN_DICTIONARY.format(page=dictionary_page, probe=telemetry_signature.probe)
+        product = "fenix"
+    return GLAM_DASHBOARD.format(
+        product=product,
+        probe=telemetry_signature.probe,
+        os=telemetry_signature.platform,
+    )
 
 
 def get_treeherder_detection_link(detection_range, telemetry_signature):


### PR DESCRIPTION
This patch integrates the lower is better setting into telemetry alerts so they can be more easily displayed everywhere. It also changes the glean dictionary links to glam graph links instead.