### PR TITLE
Bug 2055878 - Change the triage/bug due date calculation logic

### DIFF
--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -494,7 +494,7 @@ test('Alert is created on Wednesday, Bug countdown shows hours left', async () =
   alert.bug_due_date = '2022-02-16T12:41:31.419156';
 
   // current day is set to Wednesday
-  Date.now = jest.fn(() => Date.parse('2022-02-16T10:40:31.419156'));
+  Date.now = jest.fn(() => Date.parse('2022-02-16T10:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));

--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -42,7 +42,7 @@ test('Alert is created on Monday, Triage countdown shows 2 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
 test('Alert is created on Monday, Triage countdown shows 1 working days', async () => {
@@ -54,26 +54,6 @@ test('Alert is created on Monday, Triage countdown shows 1 working days', async 
 
   // current day is set to Tuesday
   Date.now = jest.fn(() => Date.parse('2022-02-08T11:41:31.419156'));
-
-  const { getByTestId } = testStatusDropdown([], alert);
-  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
-
-  fireEvent.mouseOver(dueDateIcon);
-
-  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 2 days left');
-});
-
-test('Alert is created on Monday, Triage countdown shows 1 working days', async () => {
-  const alert = testAlertSummaries[0];
-
-  // created date day is set to Monday
-  alert.created = '2022-02-07T11:41:31.419156';
-  alert.triage_due_date = '2022-02-10T11:41:31.419156';
-
-  // current day is set to Wednesday
-  Date.now = jest.fn(() => Date.parse('2022-02-09T11:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
@@ -143,7 +123,7 @@ test('Alert is created on Monday, Bug countdown shows 4 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 5 days left');
+  expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 3 working days', async () => {
@@ -164,7 +144,7 @@ test('Alert is created on Monday, Bug countdown shows 3 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 4 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 2 working days', async () => {
@@ -185,7 +165,7 @@ test('Alert is created on Monday, Bug countdown shows 2 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 1 working days', async () => {
@@ -198,27 +178,6 @@ test('Alert is created on Monday, Bug countdown shows 1 working days', async () 
 
   // current day is set to Thursday
   Date.now = jest.fn(() => Date.parse('2022-02-10T11:41:31.419156'));
-
-  const { getByTestId } = testStatusDropdown([], alert);
-  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
-
-  fireEvent.mouseOver(dueDateIcon);
-
-  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 2 days left');
-});
-
-test('Alert is created on Monday, Bug countdown shows 1 working days', async () => {
-  const alert = testAlertSummaries[0];
-
-  // created date day is set to Monday
-  alert.created = '2022-02-07T11:41:31.419156';
-  alert.first_triaged = '2022-02-07T11:41:31.419156';
-  alert.bug_due_date = '2022-02-14T11:41:31.419156';
-
-  // current day is set to Friday
-  Date.now = jest.fn(() => Date.parse('2022-02-11T11:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
@@ -293,7 +252,7 @@ test('Alert is created on Wednesday, Triage countdown shows 2 working days', asy
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows 1 working days', async () => {
@@ -314,7 +273,7 @@ test('Alert is created on Wednesday, Triage countdown shows 1 working days', asy
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 2 days left');
+  expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows hours left', async () => {
@@ -326,7 +285,7 @@ test('Alert is created on Wednesday, Triage countdown shows hours left', async (
   alert.triage_due_date = '2022-02-11T11:41:31.419156';
 
   // current day is set to Friday
-  Date.now = jest.fn(() => Date.parse('2022-02-11T11:41:31.419156'));
+  Date.now = jest.fn(() => Date.parse('2022-02-11T09:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
@@ -335,28 +294,7 @@ test('Alert is created on Wednesday, Triage countdown shows hours left', async (
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 1 days left');
-});
-
-test('Alert is created on Wednesday, Triage countdown shows Overdue when due date has been reached', async () => {
-  const alert = testAlertSummaries[0];
-
-  // created date day is set to Wednesday
-  alert.created = '2022-02-09T11:41:31.419156';
-  alert.first_triaged = '';
-  alert.triage_due_date = '2022-02-11T11:41:31.419156';
-
-  // current day is set to Monday
-  Date.now = jest.fn(() => Date.parse('2022-02-14T11:41:31.419156'));
-
-  const { getByTestId } = testStatusDropdown([], alert);
-  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
-
-  fireEvent.mouseOver(dueDateIcon);
-
-  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: Overdue');
+  expect(dueDateStatusText).toBe('Time left: 2 hours left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows Overdue', async () => {
@@ -398,7 +336,7 @@ test('Alert is created on Wednesday, Bug countdown shows 4 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 5 days left');
+  expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 3 working days', async () => {
@@ -419,7 +357,7 @@ test('Alert is created on Wednesday, Bug countdown shows 3 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 4 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 2 working days', async () => {
@@ -440,7 +378,7 @@ test('Alert is created on Wednesday, Bug countdown shows 2 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 1 working days', async () => {
@@ -453,27 +391,6 @@ test('Alert is created on Wednesday, Bug countdown shows 1 working days', async 
 
   // current day is set to Monday
   Date.now = jest.fn(() => Date.parse('2022-02-14T11:41:31.419156'));
-
-  const { getByTestId } = testStatusDropdown([], alert);
-  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
-
-  fireEvent.mouseOver(dueDateIcon);
-
-  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
-  expect(dueDateStatusText).toBe('Time left: 2 days left');
-});
-
-test('Alert is created on Wednesday, Bug countdown shows 1 working days', async () => {
-  const alert = testAlertSummaries[0];
-
-  // created date day is set to Wednesday
-  alert.created = '2022-02-09T11:41:31.419156';
-  alert.first_triaged = '2022-02-09T11:41:31.419156';
-  alert.bug_due_date = '2022-02-16T11:41:31.419156';
-
-  // current day is set to Tuesday
-  Date.now = jest.fn(() => Date.parse('2022-02-15T11:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));

--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -102,7 +102,7 @@ test('Alert is created on Monday, Triage countdown shows Overdue', async () => {
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: Overdue');
+  expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
 test('Alert is created on Monday, Bug countdown shows 4 working days', async () => {
@@ -228,7 +228,7 @@ test('Alert is created on Monday, Bug countdown shows Overdue', async () => {
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: Overdue');
+  expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
 // testing what the tooltip shows for the cases when the alert is created either on Wednesday, Thursday, Friday or the weekend
@@ -315,7 +315,7 @@ test('Alert is created on Wednesday, Triage countdown shows Overdue', async () =
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: Overdue');
+  expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 4 working days', async () => {
@@ -441,7 +441,7 @@ test('Alert is created on Wednesday, Bug countdown shows Overdue', async () => {
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: Overdue');
+  expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
 test('Alert is ready, countdown shows Ready for acknowledge', async () => {

--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -41,7 +41,7 @@ test('Alert is created on Monday, Triage countdown shows 2 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
@@ -61,7 +61,7 @@ test('Alert is created on Monday, Triage countdown shows 1 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
@@ -81,7 +81,7 @@ test('Alert is created on Monday, Triage countdown shows 1 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
@@ -101,7 +101,7 @@ test('Alert is created on Monday, Triage countdown shows hours left', async () =
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 10 hours left');
 });
 
@@ -121,7 +121,7 @@ test('Alert is created on Monday, Triage countdown shows Overdue', async () => {
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
@@ -142,7 +142,7 @@ test('Alert is created on Monday, Bug countdown shows 4 working days', async () 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 5 days left');
 });
 
@@ -163,7 +163,7 @@ test('Alert is created on Monday, Bug countdown shows 3 working days', async () 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
@@ -184,7 +184,7 @@ test('Alert is created on Monday, Bug countdown shows 2 working days', async () 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
@@ -205,7 +205,7 @@ test('Alert is created on Monday, Bug countdown shows 1 working days', async () 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
@@ -226,7 +226,7 @@ test('Alert is created on Monday, Bug countdown shows 1 working days', async () 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
@@ -247,7 +247,7 @@ test('Alert is created on Monday, Bug countdown shows hours left', async () => {
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 23 hours left');
 });
 
@@ -268,7 +268,7 @@ test('Alert is created on Monday, Bug countdown shows Overdue', async () => {
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
@@ -292,7 +292,7 @@ test('Alert is created on Wednesday, Triage countdown shows 2 working days', asy
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
@@ -313,7 +313,7 @@ test('Alert is created on Wednesday, Triage countdown shows 1 working days', asy
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
@@ -334,7 +334,7 @@ test('Alert is created on Wednesday, Triage countdown shows hours left', async (
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
@@ -355,7 +355,7 @@ test('Alert is created on Wednesday, Triage countdown shows Overdue when due dat
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
@@ -376,7 +376,7 @@ test('Alert is created on Wednesday, Triage countdown shows Overdue', async () =
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 
@@ -397,7 +397,7 @@ test('Alert is created on Wednesday, Bug countdown shows 4 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 5 days left');
 });
 
@@ -418,7 +418,7 @@ test('Alert is created on Wednesday, Bug countdown shows 3 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
@@ -439,7 +439,7 @@ test('Alert is created on Wednesday, Bug countdown shows 2 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
@@ -460,7 +460,7 @@ test('Alert is created on Wednesday, Bug countdown shows 1 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
@@ -481,7 +481,7 @@ test('Alert is created on Wednesday, Bug countdown shows 1 working days', async 
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
@@ -502,7 +502,7 @@ test('Alert is created on Wednesday, Bug countdown shows hours left', async () =
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: 2 hours left');
 });
 
@@ -523,7 +523,7 @@ test('Alert is created on Wednesday, Bug countdown shows Overdue', async () => {
   fireEvent.mouseOver(dueDateIcon);
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
-  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  const dueDateStatusText = dueDateStatus.querySelector('[data-testid="time-left"]').innerHTML;
   expect(dueDateStatusText).toBe('Time left: Overdue');
 });
 

--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -42,7 +42,7 @@ test('Alert is created on Monday, Triage countdown shows 2 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 2 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Monday, Triage countdown shows 1 working days', async () => {
@@ -62,7 +62,27 @@ test('Alert is created on Monday, Triage countdown shows 1 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 1 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
+});
+
+test('Alert is created on Monday, Triage countdown shows 1 working days', async () => {
+  const alert = testAlertSummaries[0];
+
+  // created date day is set to Monday
+  alert.created = '2022-02-07T11:41:31.419156';
+  alert.triage_due_date = '2022-02-10T11:41:31.419156';
+
+  // current day is set to Wednesday
+  Date.now = jest.fn(() => Date.parse('2022-02-09T11:41:31.419156'));
+
+  const { getByTestId } = testStatusDropdown([], alert);
+  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
+
+  fireEvent.mouseOver(dueDateIcon);
+
+  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
+  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
 test('Alert is created on Monday, Triage countdown shows hours left', async () => {
@@ -82,7 +102,7 @@ test('Alert is created on Monday, Triage countdown shows hours left', async () =
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 10 hours left');
+  expect(dueDateStatusText).toBe('Time left: 10 hours left');
 });
 
 test('Alert is created on Monday, Triage countdown shows Overdue', async () => {
@@ -123,7 +143,7 @@ test('Alert is created on Monday, Bug countdown shows 4 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 4 days left');
+  expect(dueDateStatusText).toBe('Time left: 5 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 3 working days', async () => {
@@ -144,7 +164,7 @@ test('Alert is created on Monday, Bug countdown shows 3 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 2 working days', async () => {
@@ -165,7 +185,7 @@ test('Alert is created on Monday, Bug countdown shows 2 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 2 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows 1 working days', async () => {
@@ -186,7 +206,28 @@ test('Alert is created on Monday, Bug countdown shows 1 working days', async () 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 1 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
+});
+
+test('Alert is created on Monday, Bug countdown shows 1 working days', async () => {
+  const alert = testAlertSummaries[0];
+
+  // created date day is set to Monday
+  alert.created = '2022-02-07T11:41:31.419156';
+  alert.first_triaged = '2022-02-07T11:41:31.419156';
+  alert.bug_due_date = '2022-02-14T11:41:31.419156';
+
+  // current day is set to Friday
+  Date.now = jest.fn(() => Date.parse('2022-02-11T11:41:31.419156'));
+
+  const { getByTestId } = testStatusDropdown([], alert);
+  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
+
+  fireEvent.mouseOver(dueDateIcon);
+
+  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
+  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
 test('Alert is created on Monday, Bug countdown shows hours left', async () => {
@@ -207,7 +248,7 @@ test('Alert is created on Monday, Bug countdown shows hours left', async () => {
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 23 hours left');
+  expect(dueDateStatusText).toBe('Time left: 23 hours left');
 });
 
 test('Alert is created on Monday, Bug countdown shows Overdue', async () => {
@@ -252,7 +293,7 @@ test('Alert is created on Wednesday, Triage countdown shows 2 working days', asy
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 2 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows 1 working days', async () => {
@@ -273,7 +314,7 @@ test('Alert is created on Wednesday, Triage countdown shows 1 working days', asy
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 1 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows hours left', async () => {
@@ -294,7 +335,7 @@ test('Alert is created on Wednesday, Triage countdown shows hours left', async (
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Triage: 0 hours left');
+  expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
 test('Alert is created on Wednesday, Triage countdown shows Overdue', async () => {
@@ -307,6 +348,27 @@ test('Alert is created on Wednesday, Triage countdown shows Overdue', async () =
 
   // current day is set to Monday
   Date.now = jest.fn(() => Date.parse('2022-02-14T11:41:31.419156'));
+
+  const { getByTestId } = testStatusDropdown([], alert);
+  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
+
+  fireEvent.mouseOver(dueDateIcon);
+
+  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
+  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  expect(dueDateStatusText).toBe('Time left: Overdue');
+});
+
+test('Alert is created on Wednesday, Triage countdown shows Overdue', async () => {
+  const alert = testAlertSummaries[0];
+
+  // created date day is set to Wednesday
+  alert.created = '2022-02-09T11:41:31.419156';
+  alert.first_triaged = '';
+  alert.triage_due_date = '2022-02-14T11:41:31.419156';
+
+  // current day is set to Tuesday
+  Date.now = jest.fn(() => Date.parse('2022-02-15T11:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
@@ -336,7 +398,7 @@ test('Alert is created on Wednesday, Bug countdown shows 4 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 4 days left');
+  expect(dueDateStatusText).toBe('Time left: 5 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 3 working days', async () => {
@@ -357,7 +419,7 @@ test('Alert is created on Wednesday, Bug countdown shows 3 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 3 days left');
+  expect(dueDateStatusText).toBe('Time left: 4 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 2 working days', async () => {
@@ -378,7 +440,7 @@ test('Alert is created on Wednesday, Bug countdown shows 2 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 2 days left');
+  expect(dueDateStatusText).toBe('Time left: 3 days left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows 1 working days', async () => {
@@ -399,19 +461,19 @@ test('Alert is created on Wednesday, Bug countdown shows 1 working days', async 
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 1 days left');
+  expect(dueDateStatusText).toBe('Time left: 2 days left');
 });
 
-test('Alert is created on Wednesday, Bug countdown shows hours left', async () => {
+test('Alert is created on Wednesday, Bug countdown shows 1 working days', async () => {
   const alert = testAlertSummaries[0];
 
   // created date day is set to Wednesday
   alert.created = '2022-02-09T11:41:31.419156';
   alert.first_triaged = '2022-02-09T11:41:31.419156';
-  alert.bug_due_date = '2022-02-15T10:41:31.419156';
+  alert.bug_due_date = '2022-02-16T11:41:31.419156';
 
   // current day is set to Tuesday
-  Date.now = jest.fn(() => Date.parse('2022-02-15T08:41:31.419156'));
+  Date.now = jest.fn(() => Date.parse('2022-02-15T11:41:31.419156'));
 
   const { getByTestId } = testStatusDropdown([], alert);
   const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
@@ -420,7 +482,28 @@ test('Alert is created on Wednesday, Bug countdown shows hours left', async () =
 
   const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
   const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
-  expect(dueDateStatusText).toBe('Bug: 2 hours left');
+  expect(dueDateStatusText).toBe('Time left: 1 days left');
+});
+
+test('Alert is created on Wednesday, Bug countdown shows hours left', async () => {
+  const alert = testAlertSummaries[0];
+
+  // created date day is set to Wednesday
+  alert.created = '2022-02-09T11:41:31.419156';
+  alert.first_triaged = '2022-02-09T11:41:31.419156';
+  alert.bug_due_date = '2022-02-16T12:41:31.419156';
+
+  // current day is set to Wednesday
+  Date.now = jest.fn(() => Date.parse('2022-02-16T10:40:31.419156'));
+
+  const { getByTestId } = testStatusDropdown([], alert);
+  const dueDateIcon = await waitFor(() => getByTestId('triage-clock-icon'));
+
+  fireEvent.mouseOver(dueDateIcon);
+
+  const dueDateStatus = await waitFor(() => getByTestId('due-date-status'));
+  const dueDateStatusText = dueDateStatus.querySelector('p').innerHTML;
+  expect(dueDateStatusText).toBe('Time left: 2 hours left');
 });
 
 test('Alert is created on Wednesday, Bug countdown shows Overdue', async () => {

--- a/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_status_countdown_test.jsx
@@ -338,7 +338,7 @@ test('Alert is created on Wednesday, Triage countdown shows hours left', async (
   expect(dueDateStatusText).toBe('Time left: 1 days left');
 });
 
-test('Alert is created on Wednesday, Triage countdown shows Overdue', async () => {
+test('Alert is created on Wednesday, Triage countdown shows Overdue when due date has been reached', async () => {
   const alert = testAlertSummaries[0];
 
   // created date day is set to Wednesday

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -133,13 +133,13 @@ export default class AlertStatusCountdown extends React.Component {
                       {showTriageCountdown && (
                         <div className="countdown-section">
                           <div className='fw-bold'>Bug Due: {bugDueDate}</div>
-                          <div>Time left: {countdown.triage}</div>
+                          <div data-testid="time-left">Time left: {countdown.triage}</div>
                         </div>
                       )}
                       {showBugCountdown && (
                         <div className="countdown-section">
                           <div className='fw-bold'>Bug Due: {bugDueDate}</div>
-                          <div>Time left: {countdown.bug}</div>
+                          <div data-testid="time-left">Time left: {countdown.bug}</div>
                         </div>
                       )}
                       {showReady && <h5>Ready for acknowledge</h5>}

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -132,14 +132,14 @@ export default class AlertStatusCountdown extends React.Component {
                     <div data-testid="due-date-status">
                       {showTriageCountdown && (
                         <div className="countdown-section">
-                          <h5>Triage Due: {triageDueDate}</h5>
-                          <p>Time left: {countdown.triage}</p>
+                          <div className='fw-bold'>Bug Due: {bugDueDate}</div>
+                          <div>Time left: {countdown.triage}</div>
                         </div>
                       )}
                       {showBugCountdown && (
                         <div className="countdown-section">
-                          <h5>Bug Due: {bugDueDate}</h5>
-                          <p>Time left: {countdown.bug}</p>
+                          <div className='fw-bold'>Bug Due: {bugDueDate}</div>
+                          <div>Time left: {countdown.bug}</div>
                         </div>
                       )}
                       {showReady && <h5>Ready for acknowledge</h5>}

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -97,8 +97,8 @@ export default class AlertStatusCountdown extends React.Component {
       hour: '2-digit',
       minute: '2-digit'
     };
-    triageDueDate = new Date(triageDueDate).toLocaleString('en-UK', dateOptions);
-    bugDueDate = new Date(bugDueDate).toLocaleString('en-UK', dateOptions);
+    triageDueDate = new Date(triageDueDate).toLocaleString('en-GB', dateOptions);
+    bugDueDate = new Date(bugDueDate).toLocaleString('en-GB', dateOptions);
 
     if (!alertIsTriaged(alertSummary)) {
       countdownClass = this.getCountdownClass(countdown.triage);

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -30,8 +30,8 @@ export default class AlertStatusCountdown extends React.Component {
     } = alertSummary;
 
     const currentDate = new Date(Date.now());
-    triageDueDate = new Date(triageDueDate);
-    bugDueDate = new Date(bugDueDate);
+    triageDueDate = new Date(`${triageDueDate}Z`);
+    bugDueDate = new Date(`${bugDueDate}Z`);
 
     const timeToTriageDifference = getTimeDifference(
       currentDate,
@@ -91,14 +91,14 @@ export default class AlertStatusCountdown extends React.Component {
     let showReady;
     let { triage_due_date: triageDueDate, bug_due_date: bugDueDate } = alertSummary;
 
-    const dateOptions = { 
+    const dateOptions = {
       day: 'numeric',
       month: 'short',
       hour: '2-digit',
-      minute: '2-digit'
+      minute: '2-digit',
     };
-    triageDueDate = new Date(triageDueDate).toLocaleString('en-GB', dateOptions);
-    bugDueDate = new Date(bugDueDate).toLocaleString('en-GB', dateOptions);
+    triageDueDate = new Date(`${triageDueDate}Z`).toLocaleString('en-GB', dateOptions);
+    bugDueDate = new Date(`${bugDueDate}Z`).toLocaleString('en-GB', dateOptions);
 
     if (!alertIsTriaged(alertSummary)) {
       countdownClass = this.getCountdownClass(countdown.triage);
@@ -132,13 +132,13 @@ export default class AlertStatusCountdown extends React.Component {
                     <div data-testid="due-date-status">
                       {showTriageCountdown && (
                         <div className="countdown-section">
-                          <div className='fw-bold'>Bug Due: {bugDueDate}</div>
+                          <div className="fw-bold">Triage Due: {bugDueDate}</div>
                           <div data-testid="time-left">Time left: {countdown.triage}</div>
                         </div>
                       )}
                       {showBugCountdown && (
                         <div className="countdown-section">
-                          <div className='fw-bold'>Bug Due: {bugDueDate}</div>
+                          <div className="fw-bold">Bug Due: {bugDueDate}</div>
                           <div data-testid="time-left">Time left: {countdown.bug}</div>
                         </div>
                       )}

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -89,6 +89,16 @@ export default class AlertStatusCountdown extends React.Component {
     let showTriageCountdown;
     let showBugCountdown;
     let showReady;
+    let { triage_due_date: triageDueDate, bug_due_date: bugDueDate } = alertSummary;
+
+    const dateOptions = { 
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit'
+    };
+    triageDueDate = new Date(triageDueDate).toLocaleString('en-UK', dateOptions);
+    bugDueDate = new Date(bugDueDate).toLocaleString('en-UK', dateOptions);
 
     if (!alertIsTriaged(alertSummary)) {
       countdownClass = this.getCountdownClass(countdown.triage);
@@ -121,16 +131,16 @@ export default class AlertStatusCountdown extends React.Component {
                   tooltipText={
                     <div data-testid="due-date-status">
                       {showTriageCountdown && (
-                        <>
-                          <h5>Due date:</h5>
-                          <p>Triage: {countdown.triage}</p>
-                        </>
+                        <div className="countdown-section">
+                          <h5>Triage Due: {triageDueDate}</h5>
+                          <p>Time left: {countdown.triage}</p>
+                        </div>
                       )}
                       {showBugCountdown && (
-                        <>
-                          <h5>Due date:</h5>
-                          <p>Bug: {countdown.bug}</p>
-                        </>
+                        <div className="countdown-section">
+                          <h5>Bug Due: {bugDueDate}</h5>
+                          <p>Time left: {countdown.bug}</p>
+                        </div>
                       )}
                       {showReady && <h5>Ready for acknowledge</h5>}
                     </div>

--- a/ui/perfherder/alerts/AlertStatusCountdown.jsx
+++ b/ui/perfherder/alerts/AlertStatusCountdown.jsx
@@ -132,7 +132,7 @@ export default class AlertStatusCountdown extends React.Component {
                     <div data-testid="due-date-status">
                       {showTriageCountdown && (
                         <div className="countdown-section">
-                          <div className="fw-bold">Triage Due: {bugDueDate}</div>
+                          <div className="fw-bold">Triage Due: {triageDueDate}</div>
                           <div data-testid="time-left">Time left: {countdown.triage}</div>
                         </div>
                       )}

--- a/ui/perfherder/perf-helpers/alertCountdownHelper.js
+++ b/ui/perfherder/perf-helpers/alertCountdownHelper.js
@@ -22,7 +22,7 @@ export const getTimeDifference = (currentDate, dueDate) => {
 
   // step forward exactly 24 hours at a time to count weekend days
   while (tempDate < dueDate) {
-    const dayOfWeek = tempDate.getUTCDay();
+    const dayOfWeek = tempDate.getDay();
 
     if (dayOfWeek === weekdays.sunday || dayOfWeek === weekdays.saturday) {
       weekendDays++;

--- a/ui/perfherder/perf-helpers/alertCountdownHelper.js
+++ b/ui/perfherder/perf-helpers/alertCountdownHelper.js
@@ -8,50 +8,45 @@ export const isWeekend = () => {
 };
 
 export const getTimeDifference = (currentDate, dueDate) => {
-  const timeDifference = Math.abs(dueDate - currentDate);
-  let differenceInDays = Math.ceil(timeDifference / (1000 * 60 * 60 * 24));
-  // saturday and sunday are considered weekend days
-  const weekendDaysCount = 2;
-  // convert days to weeks and keeps the count of full weeks
-  const weeksCount = Math.trunc(differenceInDays / 7);
-  // count the total weekend days
-  const weekendDaysToSubstract = weekendDaysCount * weeksCount;
-  const currentDay = currentDate.getUTCDay();
-  const dueDay = dueDate.getUTCDay();
+  const msInHour = 1000 * 60 * 60;
+  const msInDay = msInHour * 24;
+  const totalMs = dueDate.getTime() - currentDate.getTime();
 
-  // [1. Mon] [2. Tue] [3. Wed] [4. Thu]    [5. Fri] [6. Sat] [7. Sun]
-  //                            currentDate -------- -------- ----->>>
-  // -------- -------> dueDate
-  if (currentDay > dueDay) {
-    // If weekday of startDate is bigger than endDate then it is a new week,
-    // and we have to subtract the weekend days
-    differenceInDays -= weekendDaysCount;
-  } else {
-    // substracts the total weekend days from the total days
-    differenceInDays -= weekendDaysToSubstract;
+  // if the due date is in the past, return 0
+  if (totalMs <= 0) {
+    return { hours: 0, days: 0 };
   }
 
-  let hoursDifference = Math.ceil(timeDifference / (1000 * 60 * 60));
-  const shouldGetHoursLeft =
-    currentDay === weekdays.friday && dueDay === weekdays.monday;
-  // If due date is Monday and today is Friday and we have to show the hours left,
-  // we have to subtract the weekend hours from the difference
-  if (shouldGetHoursLeft) {
-    hoursDifference -= 2 * 24;
+  let weekendDays = 0;
+  let tempDate = new Date(currentDate.getTime());
+
+  // step forward exactly 24 hours at a time to count weekend days
+  while (tempDate < dueDate) {
+    const dayOfWeek = tempDate.getUTCDay();
+
+    if (dayOfWeek === weekdays.sunday || dayOfWeek === weekdays.saturday) {
+      weekendDays++;
+    }
+    tempDate.setTime(tempDate.getTime() + msInDay);
   }
+
+  // subtract the weekend time from the total time
+  const workingMs = Math.max(0, totalMs - (weekendDays * msInDay));
+
   return {
-    hours: hoursDifference,
-    days: differenceInDays,
+    hours: Math.ceil(workingMs / msInHour),
+    days: Math.ceil(workingMs / msInDay),
   };
 };
 
 export const getCountdownText = (now, dueDate, difference) => {
-  if (difference.hours < 24 && difference.hours >= 0) {
-    return `${difference.hours} hours left`;
-  }
-
+  // check if it's overdue first
   if (now.getTime() >= dueDate.getTime()) {
     return `Overdue`;
+  }
+
+  if (difference.hours < 24 && difference.hours >= 0) {
+    return `${difference.hours} hours left`;
   }
 
   return `${difference.days} days left`;

--- a/ui/perfherder/perf-helpers/alertCountdownHelper.js
+++ b/ui/perfherder/perf-helpers/alertCountdownHelper.js
@@ -2,7 +2,7 @@ import { weekdays } from './constants';
 
 export const isWeekend = () => {
   const currentDate = new Date(Date.now());
-  const currentDay = currentDate.getDay();
+  const currentDay = currentDate.getUTCDay();
 
   return currentDay === weekdays.saturday || currentDay === weekdays.sunday;
 };
@@ -22,7 +22,7 @@ export const getTimeDifference = (currentDate, dueDate) => {
 
   // step forward exactly 24 hours at a time to count weekend days
   while (tempDate < dueDate) {
-    const dayOfWeek = tempDate.getDay();
+    const dayOfWeek = tempDate.getUTCDay();
 
     if (dayOfWeek === weekdays.sunday || dayOfWeek === weekdays.saturday) {
       weekendDays++;


### PR DESCRIPTION
[Bug 2055878 - Change the triage/bug due date calculation logic](https://bugzilla.mozilla.org/show_bug.cgi?id=2055878)

The current logic for calculating the time difference between the current time and the due date for triage/bugs has several flaws:
- because the value is calculated as an absolute value, already due dates such as -3h show as "3h left" in the UI
- overdue alerts only show as overdue after 24h since actually being overdue, also because of the absolute value
- the overall logic is pretty rigid and omits some edge cases

Also, the clock tooltip now shows the actual due date alongside the remaining calculated time
<img width="232" height="145" alt="image" src="https://github.com/user-attachments/assets/b597d238-1c39-47a1-9cd5-20c4c97b39da" />

