### PR TITLE
Bug 1499551 - Fix accumulating window event-listener leaks (part 1/3)

### DIFF
--- a/tests/ui/perfherder/graphs-view/graphs_container_test.jsx
+++ b/tests/ui/perfherder/graphs-view/graphs_container_test.jsx
@@ -1,0 +1,40 @@
+import GraphsContainer from '../../../../ui/perfherder/graphs/GraphsContainer';
+
+describe('GraphsContainer', () => {
+  const buildInstance = () => {
+    const instance = new GraphsContainer({
+      // One minimal visible data point so initZoomDomain has x/y values.
+      testData: [{ visible: true, data: [{ x: 1, y: 1 }] }],
+      measurementUnits: new Set(),
+      updateStateParams: () => {},
+      timeRange: { value: 86400 },
+    });
+    // Stub the side-effecting mount helpers we are not exercising here.
+    instance.addHighlights = () => {};
+    instance.buildInitialRunsCache = () => {};
+    instance.setState = () => {};
+    return instance;
+  };
+
+  test('adds a resize listener on mount and removes the same handler on unmount', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const instance = buildInstance();
+
+    instance.componentDidMount();
+    const addedCall = addSpy.mock.calls.find(([type]) => type === 'resize');
+    expect(addedCall).toBeDefined();
+
+    instance.componentWillUnmount();
+    const removedCall = removeSpy.mock.calls.find(
+      ([type]) => type === 'resize',
+    );
+    expect(removedCall).toBeDefined();
+    // The exact same handler reference must be removed, or the listener leaks.
+    expect(removedCall[1]).toBe(addedCall[1]);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});

--- a/tests/ui/shared/FailureSummaryTab_test.jsx
+++ b/tests/ui/shared/FailureSummaryTab_test.jsx
@@ -10,6 +10,7 @@ import { MemoryRouter } from 'react-router';
 
 import { getApiUrl } from '../../../ui/helpers/url';
 import { getProjectUrl } from '../../../ui/helpers/location';
+import { thEvents } from '../../../ui/helpers/constants';
 import PinBoard from '../../../ui/job-view/details/PinBoard';
 import {
   addBug,
@@ -78,6 +79,30 @@ describe('FailureSummaryTab', () => {
         'TEST-UNEXPECTED-FAIL | devtools/client/netmonitor/src/har/test/browser_net_har_copy_all_as_har.js | There must be some page title -',
       ),
     ).toBeInTheDocument();
+  });
+
+  test('removes its internalIssueClassification listener on unmount', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener');
+    const removeSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(testFailureSummaryTab());
+
+    const eventType = thEvents.internalIssueClassification;
+    const addedHandler = addSpy.mock.calls.find(
+      ([type]) => type === eventType,
+    )[1];
+
+    unmount();
+
+    const removedCall = removeSpy.mock.calls.find(
+      ([type]) => type === eventType,
+    );
+
+    expect(removedCall).toBeDefined();
+    expect(removedCall[1]).toBe(addedHandler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 
   test('suggested duplicate bugs should mention open bug', async () => {

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -53,20 +53,24 @@ class GraphsContainer extends React.Component {
 
   componentDidMount() {
     const { selectedDataPoint } = this.props;
-    const { scatterPlotData } = this.state;
-    const zoomDomain = this.initZoomDomain(scatterPlotData);
     this.addHighlights();
     this.buildInitialRunsCache();
     if (selectedDataPoint) {
       this.verifySelectedDataPoint();
     }
-    window.addEventListener('resize', () =>
-      this.setState({
-        width: window.innerWidth,
-        zoomDomain,
-      }),
-    );
+    window.addEventListener('resize', this.handleResize);
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  handleResize = () => {
+    this.setState((prevState) => ({
+      width: window.innerWidth,
+      zoomDomain: this.initZoomDomain(prevState.scatterPlotData),
+    }));
+  };
 
   componentDidUpdate(prevProps) {
     const {

--- a/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
+++ b/ui/shared/tabs/failureSummary/FailureSummaryTab.jsx
@@ -35,10 +35,22 @@ class FailureSummaryTab extends React.Component {
   componentDidMount() {
     this.loadBugSuggestions();
 
-    window.addEventListener(thEvents.internalIssueClassification, (event) =>
-      this.checkInternalFailureOccurrences(event.detail.internalBugId),
+    window.addEventListener(
+      thEvents.internalIssueClassification,
+      this.handleInternalIssueClassification,
     );
   }
+
+  componentWillUnmount() {
+    window.removeEventListener(
+      thEvents.internalIssueClassification,
+      this.handleInternalIssueClassification,
+    );
+  }
+
+  handleInternalIssueClassification = (event) => {
+    this.checkInternalFailureOccurrences(event.detail.internalBugId);
+  };
 
   componentDidUpdate(prevProps) {
     const { selectedJobId } = this.props;


### PR DESCRIPTION
Part 1 of 3 addressing Bug 1499551 (jobs-view memory/CPU growth over time).

Two class components added a `window` event listener with an anonymous handler and no `componentWillUnmount`, so each mount permanently accumulated a listener (and its captured component instance):

- `FailureSummaryTab` (`internalIssueClassification`) — remounts on every job selection.
- `GraphsContainer` (`resize`) — remounts on every test/time-range change.

Both now store the handler as a stable class-property arrow and remove that same reference on unmount. `GraphsContainer`'s resize handler recomputes `zoomDomain` from current `scatterPlotData` (via the existing `initZoomDomain`) instead of capturing a stale mount-time value.

Independent of the other two Bug 1499551 PRs.

## Testing
- New unit tests assert the same handler reference is removed on unmount.
- Full frontend unit suite passes; lint clean.