### PR TITLE
Bug 1499551 - Bound jobs-view memory: per-repo push cap + idle-timeout polling (part 2/3)

### DIFF
--- a/tests/ui/hooks/usePollingLifecycle_test.jsx
+++ b/tests/ui/hooks/usePollingLifecycle_test.jsx
@@ -1,0 +1,112 @@
+import { renderHook, act } from '@testing-library/react';
+
+import usePollingLifecycle, {
+  PUSH_POLL_INTERVAL,
+  IDLE_POLL_TIMEOUT_DEFAULT,
+  IDLE_POLL_TIMEOUT_KEEPALIVE,
+} from '../../../ui/hooks/usePollingLifecycle';
+import { usePollControlStore } from '../../../ui/shared/stores/pollControlStore';
+
+const setHidden = (hidden) => {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  });
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible'),
+  });
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+};
+
+describe('usePollingLifecycle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    usePollControlStore.setState({ keepAlive: false, pollingPaused: false });
+    setHidden(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('polls on the interval while the tab is visible', () => {
+    const pollPushes = jest.fn();
+    renderHook(() => usePollingLifecycle(pollPushes));
+
+    act(() => jest.advanceTimersByTime(PUSH_POLL_INTERVAL * 3));
+
+    expect(pollPushes).toHaveBeenCalledTimes(3);
+  });
+
+  test('stops polling after the idle timeout while backgrounded', () => {
+    const pollPushes = jest.fn();
+    renderHook(() => usePollingLifecycle(pollPushes));
+
+    setHidden(true);
+    act(() => jest.advanceTimersByTime(IDLE_POLL_TIMEOUT_DEFAULT));
+
+    expect(usePollControlStore.getState().pollingPaused).toBe(true);
+
+    // Interval is cleared: no further polls happen while stopped.
+    pollPushes.mockClear();
+    act(() => jest.advanceTimersByTime(PUSH_POLL_INTERVAL * 5));
+    expect(pollPushes).not.toHaveBeenCalled();
+  });
+
+  test('resumes with a catch-up poll when brought back to the foreground', () => {
+    const pollPushes = jest.fn();
+    renderHook(() => usePollingLifecycle(pollPushes));
+
+    setHidden(true);
+    act(() => jest.advanceTimersByTime(IDLE_POLL_TIMEOUT_DEFAULT));
+    expect(usePollControlStore.getState().pollingPaused).toBe(true);
+
+    pollPushes.mockClear();
+    setHidden(false);
+
+    // Immediate catch-up poll on resume, and polling is no longer paused.
+    expect(pollPushes).toHaveBeenCalledTimes(1);
+    expect(usePollControlStore.getState().pollingPaused).toBe(false);
+
+    act(() => jest.advanceTimersByTime(PUSH_POLL_INTERVAL));
+    expect(pollPushes).toHaveBeenCalledTimes(2);
+  });
+
+  test('refocusing before the idle timeout keeps polling and resets the clock', () => {
+    const pollPushes = jest.fn();
+    renderHook(() => usePollingLifecycle(pollPushes));
+
+    setHidden(true);
+    act(() => jest.advanceTimersByTime(IDLE_POLL_TIMEOUT_DEFAULT - 1000));
+    setHidden(false); // refocus just before the limit
+
+    expect(usePollControlStore.getState().pollingPaused).toBe(false);
+    // Was never paused, so no catch-up poll fired and the interval kept running.
+    pollPushes.mockClear();
+    act(() => jest.advanceTimersByTime(PUSH_POLL_INTERVAL));
+    expect(pollPushes).toHaveBeenCalledTimes(1);
+  });
+
+  test('keep-alive extends the idle timeout to 12 hours', () => {
+    const pollPushes = jest.fn();
+    usePollControlStore.setState({ keepAlive: true });
+    renderHook(() => usePollingLifecycle(pollPushes));
+
+    setHidden(true);
+    // Past the default limit but under the keep-alive limit: still polling.
+    act(() => jest.advanceTimersByTime(IDLE_POLL_TIMEOUT_DEFAULT));
+    expect(usePollControlStore.getState().pollingPaused).toBe(false);
+
+    // Past the keep-alive limit: now stopped.
+    act(() =>
+      jest.advanceTimersByTime(
+        IDLE_POLL_TIMEOUT_KEEPALIVE - IDLE_POLL_TIMEOUT_DEFAULT,
+      ),
+    );
+    expect(usePollControlStore.getState().pollingPaused).toBe(true);
+  });
+});

--- a/tests/ui/job-view/headerbars/KeepAliveButton_test.jsx
+++ b/tests/ui/job-view/headerbars/KeepAliveButton_test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import KeepAliveButton from '../../../../ui/job-view/headerbars/KeepAliveButton';
+import { usePollControlStore } from '../../../../ui/shared/stores/pollControlStore';
+
+describe('KeepAliveButton', () => {
+  beforeEach(() => {
+    usePollControlStore.setState({ keepAlive: false, pollingPaused: false });
+  });
+
+  afterEach(cleanup);
+
+  test('toggles keep-alive when clicked', () => {
+    render(<KeepAliveButton />);
+
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(button);
+
+    expect(usePollControlStore.getState().keepAlive).toBe(true);
+    expect(screen.getByRole('button').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('shows the paused indicator only while polling is paused', () => {
+    const { rerender } = render(<KeepAliveButton />);
+    expect(screen.queryByText('Updates paused')).toBeNull();
+
+    usePollControlStore.setState({ pollingPaused: true });
+    rerender(<KeepAliveButton />);
+
+    expect(screen.getByText('Updates paused')).toBeInTheDocument();
+  });
+});

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -15,6 +15,7 @@ import {
   usePushesStore,
   initialState,
   enforcePushLimit,
+  getRepoPushCap,
 } from '../../../../ui/shared/stores/pushesStore';
 import { useSelectedJobStore } from '../../../../ui/shared/stores/selectedJobStore';
 import { usePinnedJobsStore } from '../../../../ui/shared/stores/pinnedJobsStore';
@@ -70,7 +71,18 @@ describe('Pushes Zustand store', () => {
     expect(state.revisionTips).toEqual(revisionTips);
   });
 
-  test('retainedPushLimit rises to the loaded push count on explicit fetchPushes', async () => {
+  test('getRepoPushCap returns 200 for autoland and 100 for other repos', () => {
+    window.location = { ...originalLocation, search: '?repo=autoland' };
+    expect(getRepoPushCap()).toBe(200);
+
+    window.location = { ...originalLocation, search: '?repo=try' };
+    expect(getRepoPushCap()).toBe(100);
+
+    window.location = { ...originalLocation, search: '' };
+    expect(getRepoPushCap()).toBe(100);
+  });
+
+  test('fetchPushes floors retainedPushLimit at the repo push cap', async () => {
     fetchMock.get(
       getProjectUrl('/push/?full=true&count=10', repoName),
       pushListFixture,
@@ -80,11 +92,12 @@ describe('Pushes Zustand store', () => {
       emptyBugzillaResponse,
     );
 
+    // No repo in the URL => default cap of 100 is the floor, above the 6-push
+    // fixture, so the limit lands on the cap rather than the loaded count.
     usePushesStore.setState(initialState);
     await usePushesStore.getState().fetchPushes();
 
-    // BASE_RETAINED_PUSHES is 50; the 6-push fixture keeps the limit at BASE.
-    expect(usePushesStore.getState().retainedPushLimit).toBe(50);
+    expect(usePushesStore.getState().retainedPushLimit).toBe(100);
   });
 
   const buildPushList = (ids) =>

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -14,7 +14,10 @@ import revisionTips from '../../mock/revisionTips.json';
 import {
   usePushesStore,
   initialState,
+  enforcePushLimit,
 } from '../../../../ui/shared/stores/pushesStore';
+import { useSelectedJobStore } from '../../../../ui/shared/stores/selectedJobStore';
+import { usePinnedJobsStore } from '../../../../ui/shared/stores/pinnedJobsStore';
 import { getApiUrl } from '../../../../ui/helpers/url';
 import JobModel from '../../../../ui/models/job';
 
@@ -34,6 +37,8 @@ describe('Pushes Zustand store', () => {
     window.location = { ...originalLocation, search: '', pathname: '/jobs' };
     // Reset store to initial state before each test
     usePushesStore.setState(initialState);
+    useSelectedJobStore.setState({ selectedJob: null });
+    usePinnedJobsStore.setState({ pinnedJobs: {} });
   });
 
   afterEach(() => {
@@ -80,6 +85,59 @@ describe('Pushes Zustand store', () => {
 
     // BASE_RETAINED_PUSHES is 50; the 6-push fixture keeps the limit at BASE.
     expect(usePushesStore.getState().retainedPushLimit).toBe(50);
+  });
+
+  const buildPushList = (ids) =>
+    ids.map((id) => ({
+      id,
+      revision: `rev${id}`,
+      author: 'a@b.com',
+      push_timestamp: 1000 + id,
+      revisions: [{ comments: `title ${id}` }],
+      jobsLoaded: true,
+    }));
+
+  test('enforcePushLimit evicts oldest pushes beyond retainedPushLimit and prunes jobMap', () => {
+    const pushList = buildPushList([5, 4, 3, 2, 1]); // newest-first
+    const jobMap = {};
+    pushList.forEach((p) => {
+      jobMap[p.id * 10] = {
+        id: p.id * 10,
+        push_id: p.id,
+        state: 'completed',
+        result: 'success',
+        last_modified: '2019-08-05T20:00:00',
+      };
+    });
+
+    usePushesStore.setState({
+      ...initialState,
+      pushList,
+      jobMap,
+      retainedPushLimit: 3,
+    });
+
+    usePushesStore.setState((state) => enforcePushLimit(state));
+    const state = usePushesStore.getState();
+
+    expect(state.pushList.map((p) => p.id)).toEqual([5, 4, 3]);
+    expect(Object.keys(state.jobMap).sort()).toEqual(['30', '40', '50']);
+    expect(state.oldestPushTimestamp).toBe(1003);
+  });
+
+  test('enforcePushLimit never evicts the selected or a pinned push', () => {
+    const pushList = buildPushList([5, 4, 3, 2, 1]);
+
+    usePushesStore.setState({ ...initialState, pushList, retainedPushLimit: 3 });
+    // Select a job on the oldest push (id 1); pin a job on push id 2.
+    useSelectedJobStore.setState({ selectedJob: { id: 999, push_id: 1 } });
+    usePinnedJobsStore.setState({ pinnedJobs: { 998: { id: 998, push_id: 2 } } });
+
+    usePushesStore.setState((state) => enforcePushLimit(state));
+    const keptIds = usePushesStore.getState().pushList.map((p) => p.id);
+
+    // 3 newest kept, plus protected pushes 1 and 2.
+    expect(keptIds.sort((a, b) => b - a)).toEqual([5, 4, 3, 2, 1]);
   });
 
   test('should add new push and jobs when polling', async () => {

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -65,6 +65,23 @@ describe('Pushes Zustand store', () => {
     expect(state.revisionTips).toEqual(revisionTips);
   });
 
+  test('retainedPushLimit rises to the loaded push count on explicit fetchPushes', async () => {
+    fetchMock.get(
+      getProjectUrl('/push/?full=true&count=10', repoName),
+      pushListFixture,
+    );
+    fetchMock.get(
+      `https://bugzilla.mozilla.org/rest/bug?id=1556854%2C1555861%2C1559418%2C1563766%2C1561537%2C1563692`,
+      emptyBugzillaResponse,
+    );
+
+    usePushesStore.setState(initialState);
+    await usePushesStore.getState().fetchPushes();
+
+    // BASE_RETAINED_PUSHES is 50; the 6-push fixture keeps the limit at BASE.
+    expect(usePushesStore.getState().retainedPushLimit).toBe(50);
+  });
+
   test('should add new push and jobs when polling', async () => {
     fetchMock.get(
       getProjectUrl(

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -191,6 +191,37 @@ describe('Pushes Zustand store', () => {
     ]);
   });
 
+  test('pollPushes trims the pushList back to retainedPushLimit', async () => {
+    fetchMock.get(
+      getProjectUrl(
+        '/push/?full=true&count=100&fromchange=ba9c692786e95143b8df3f4b3e9b504dfbc589a0',
+        repoName,
+      ),
+      pollPushListFixture,
+    );
+    fetchMock.mock(`begin:${getApiUrl('/jobs/?push_id__in=', repoName)}`, {
+      count: 0,
+      next: null,
+      results: [],
+    });
+    fetchMock.get(
+      `https://bugzilla.mozilla.org/rest/bug?id=1506219`,
+      emptyBugzillaResponse,
+    );
+
+    const initialPush = pushListFixture.results[0];
+    // limit 1 => after polling prepends pushes, only the newest remains.
+    usePushesStore.setState({
+      ...initialState,
+      pushList: [initialPush],
+      retainedPushLimit: 1,
+    });
+
+    await usePushesStore.getState().pollPushes();
+
+    expect(usePushesStore.getState().pushList).toHaveLength(1);
+  });
+
   test('fetchPushes should update revision param on url', async () => {
     fetchMock.get(
       getProjectUrl(

--- a/tests/ui/shared/pollControlStore_test.jsx
+++ b/tests/ui/shared/pollControlStore_test.jsx
@@ -1,0 +1,31 @@
+import {
+  usePollControlStore,
+  setKeepAlive,
+  toggleKeepAlive,
+  setPollingPaused,
+} from '../../../ui/shared/stores/pollControlStore';
+
+describe('pollControlStore', () => {
+  beforeEach(() => {
+    usePollControlStore.setState({ keepAlive: false, pollingPaused: false });
+  });
+
+  test('defaults to keep-alive off and not paused', () => {
+    const state = usePollControlStore.getState();
+    expect(state.keepAlive).toBe(false);
+    expect(state.pollingPaused).toBe(false);
+  });
+
+  test('setKeepAlive and toggleKeepAlive update keepAlive', () => {
+    setKeepAlive(true);
+    expect(usePollControlStore.getState().keepAlive).toBe(true);
+
+    toggleKeepAlive();
+    expect(usePollControlStore.getState().keepAlive).toBe(false);
+  });
+
+  test('setPollingPaused updates pollingPaused', () => {
+    setPollingPaused(true);
+    expect(usePollControlStore.getState().pollingPaused).toBe(true);
+  });
+});

--- a/ui/hooks/usePollingLifecycle.js
+++ b/ui/hooks/usePollingLifecycle.js
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+import { usePollControlStore } from '../shared/stores/pollControlStore';
+
+export const PUSH_POLL_INTERVAL = 60000; // 1 minute
+export const IDLE_POLL_TIMEOUT_DEFAULT = 2 * 60 * 60 * 1000; // 2 hours
+export const IDLE_POLL_TIMEOUT_KEEPALIVE = 12 * 60 * 60 * 1000; // 12 hours
+
+// Manages the jobs-view push/job poll: a periodic interval plus a Page
+// Visibility idle timeout. Once a tab has been backgrounded for longer than its
+// idle limit (2h, or 12h with keep-alive) polling stops so a forgotten tab
+// stops accumulating data. Bringing the tab back to the foreground resumes
+// polling (with one immediate catch-up poll) and resets the idle clock.
+export default function usePollingLifecycle(pollPushes) {
+  const keepAlive = usePollControlStore((state) => state.keepAlive);
+  const setPollingPaused = usePollControlStore(
+    (state) => state.setPollingPaused,
+  );
+
+  const intervalRef = useRef(null);
+  const idleTimerRef = useRef(null);
+  // Read the current keep-alive value from a ref so toggling it never has to
+  // re-register the visibility listener.
+  const keepAliveRef = useRef(keepAlive);
+
+  useEffect(() => {
+    keepAliveRef.current = keepAlive;
+  }, [keepAlive]);
+
+  const startPolling = useCallback(() => {
+    if (intervalRef.current === null) {
+      intervalRef.current = setInterval(() => {
+        pollPushes();
+      }, PUSH_POLL_INTERVAL);
+    }
+    setPollingPaused(false);
+  }, [pollPushes, setPollingPaused]);
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setPollingPaused(true);
+  }, [setPollingPaused]);
+
+  const handleVisibilityChange = useCallback(() => {
+    if (document.hidden) {
+      // Backgrounded: stop polling after the idle limit of continuous hiding.
+      const limit = keepAliveRef.current
+        ? IDLE_POLL_TIMEOUT_KEEPALIVE
+        : IDLE_POLL_TIMEOUT_DEFAULT;
+      idleTimerRef.current = setTimeout(stopPolling, limit);
+    } else {
+      // Foregrounded: cancel any pending idle stop; if polling had been paused,
+      // resume it with an immediate catch-up poll.
+      if (idleTimerRef.current !== null) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+      if (intervalRef.current === null) {
+        pollPushes();
+        startPolling();
+      }
+    }
+  }, [pollPushes, startPolling, stopPolling]);
+
+  useEffect(() => {
+    startPolling();
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      if (idleTimerRef.current !== null) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+  }, [startPolling, handleVisibilityChange]);
+}

--- a/ui/job-view/headerbars/KeepAliveButton.jsx
+++ b/ui/job-view/headerbars/KeepAliveButton.jsx
@@ -1,0 +1,48 @@
+import { Button } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faMugHot } from '@fortawesome/free-solid-svg-icons';
+
+import {
+  usePollControlStore,
+  toggleKeepAlive,
+} from '../../shared/stores/pollControlStore';
+
+// Toolbar toggle (a coffee mug) that keeps a backgrounded tab polling for the
+// longer idle window. Filled/active mug = keep-alive on (12h); muted mug =
+// default (2h). While polling is paused from inactivity, shows an indicator.
+export default function KeepAliveButton() {
+  const keepAlive = usePollControlStore((state) => state.keepAlive);
+  const pollingPaused = usePollControlStore((state) => state.pollingPaused);
+
+  const title = keepAlive
+    ? 'Keep-alive on: this tab keeps updating in the background for up to 12 hours. Click to return to the 2 hour default.'
+    : 'Keep-alive off: background updates stop after 2 hours of inactivity. Click to extend to 12 hours.';
+
+  return (
+    <>
+      {pollingPaused && (
+        <span
+          className="navbar-badge badge badge-warning badge-pill"
+          id="polling-paused-indicator"
+          title="Background updates paused after inactivity. Focus this tab to resume."
+        >
+          Updates paused
+        </span>
+      )}
+      <Button
+        size="sm"
+        className={`btn-view-nav nav-menu-btn${keepAlive ? ' active' : ''}`}
+        onClick={toggleKeepAlive}
+        aria-pressed={keepAlive}
+        title={title}
+        id="keep-alive-btn"
+      >
+        <FontAwesomeIcon
+          icon={faMugHot}
+          className={keepAlive ? undefined : 'text-muted'}
+          title="keep-alive"
+        />
+      </Button>
+    </>
+  );
+}

--- a/ui/job-view/headerbars/SecondaryNavBar.jsx
+++ b/ui/job-view/headerbars/SecondaryNavBar.jsx
@@ -22,6 +22,7 @@ import {
 
 import TierIndicator from './TierIndicator';
 import WatchedRepo from './WatchedRepo';
+import KeepAliveButton from './KeepAliveButton';
 
 const MAX_WATCHED_REPOS = 3;
 const WATCHED_REPOS_STORAGE_KEY = 'thWatchedRepos';
@@ -298,6 +299,9 @@ const SecondaryNavBar = ({
             </span>
             )
           </Button>
+
+          {/* Keep-alive toggle for background polling */}
+          <KeepAliveButton />
 
           {/* Result Status Filter Chicklets */}
           <span className="resultStatusChicklets">

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -19,10 +19,10 @@ import {
 } from '../../shared/stores/pushesStore';
 import { updatePushParams } from '../../helpers/location';
 
+import usePollingLifecycle from '../../hooks/usePollingLifecycle';
+
 import Push from './Push';
 import PushLoadErrors from './PushLoadErrors';
-
-const PUSH_POLL_INTERVAL = 60000;
 
 /**
  * URL-FIRST ARCHITECTURE
@@ -62,7 +62,6 @@ function PushList({
   );
   const location = useLocation();
   const [notificationSupported] = useState('Notification' in window);
-  const pushIntervalId = useRef(null);
   const prevRouterSearch = useRef(location.search);
   const prevJobsLoaded = useRef(jobsLoaded);
 
@@ -94,12 +93,6 @@ function PushList({
     },
     [location.search, updateRange, getUrlRangeValues],
   );
-
-  const poll = useCallback(() => {
-    pushIntervalId.current = setInterval(async () => {
-      pollPushes();
-    }, PUSH_POLL_INTERVAL);
-  }, [pollPushes]);
 
   const clearIfEligibleTarget = useCallback(
     (target) => {
@@ -134,17 +127,9 @@ function PushList({
     document.title = `[${allUnclassifiedFailureCount}] ${repoName}`;
   }, [allUnclassifiedFailureCount, repoName]);
 
-  // componentDidMount - start polling
-  useEffect(() => {
-    poll();
-
-    return () => {
-      if (pushIntervalId.current) {
-        clearInterval(pushIntervalId.current);
-        pushIntervalId.current = null;
-      }
-    };
-  }, [poll]);
+  // Start the push/job poll, with an idle timeout that stops it when the tab
+  // is left in the background past its limit (see usePollingLifecycle).
+  usePollingLifecycle(pollPushes);
 
   // Sync selection from URL when jobs first load
   useEffect(() => {

--- a/ui/shared/stores/pollControlStore.js
+++ b/ui/shared/stores/pollControlStore.js
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+// Per-tab controls for the jobs-view push/job polling lifecycle.
+// - keepAlive: user opted (via the toolbar coffee mug) to keep a backgrounded
+//   tab polling for the longer idle window. Default off, not persisted, so a
+//   forgotten tab is never accidentally kept alive.
+// - pollingPaused: polling has been stopped because the tab sat in the
+//   background past its idle limit. Cleared automatically when the tab is
+//   brought back to the foreground.
+export const usePollControlStore = create(
+  devtools(
+    (set) => ({
+      keepAlive: false,
+      pollingPaused: false,
+
+      setKeepAlive: (keepAlive) => set({ keepAlive }),
+      toggleKeepAlive: () => set((state) => ({ keepAlive: !state.keepAlive })),
+      setPollingPaused: (pollingPaused) => set({ pollingPaused }),
+    }),
+    { name: 'poll-control-store' },
+  ),
+);
+
+// Standalone functions for use outside React components.
+export const setKeepAlive = (keepAlive) =>
+  usePollControlStore.getState().setKeepAlive(keepAlive);
+export const toggleKeepAlive = () =>
+  usePollControlStore.getState().toggleKeepAlive();
+export const setPollingPaused = (pollingPaused) =>
+  usePollControlStore.getState().setPollingPaused(pollingPaused);

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -336,6 +336,8 @@ export const usePushesStore = create(
               bugSummaryMap,
             );
             set({ loadingPushes: false, ...pushResults });
+            // Bound poll-driven push growth before fetching jobs for them.
+            set((state) => enforcePushLimit(state));
             fetchNewJobs();
           } else {
             notify('Error fetching new push data', 'danger', { sticky: true });

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -23,11 +23,14 @@ import {
 import { usePinnedJobsStore } from './pinnedJobsStore';
 
 const DEFAULT_PUSH_COUNT = 10;
-// Upper bound on pushes retained while polling. Generous enough that normal
-// short sessions never evict a push from the initial viewport, small enough to
-// bound memory for a multi-hour tab. Explicit "get more pushes" loads raise the
-// effective limit (see retainedPushLimit) so the user is never fought.
-const BASE_RETAINED_PUSHES = 50;
+// Rolling cap on pushes retained while polling. autoland gets a larger window
+// (sheriffs watch it closely); other repos are capped tighter. This is only a
+// floor: explicit "get more pushes" loads raise retainedPushLimit above it, so
+// polling growth is bounded while the user can still browse deeper history.
+const AUTOLAND_PUSH_CAP = 200;
+const DEFAULT_PUSH_CAP = 100;
+export const getRepoPushCap = () =>
+  getUrlParam('repo') === 'autoland' ? AUTOLAND_PUSH_CAP : DEFAULT_PUSH_CAP;
 const PUSH_POLLING_KEYS = ['tochange', 'enddate', 'revision', 'author'];
 const PUSH_FETCH_KEYS = [...PUSH_POLLING_KEYS, 'fromchange', 'startdate'];
 
@@ -128,7 +131,8 @@ const getProtectedPushIds = () => {
 // partial state object (empty when nothing needs evicting).
 export const enforcePushLimit = (state) => {
   const { pushList, jobMap, decisionTaskMap, retainedPushLimit } = state;
-  if (pushList.length <= retainedPushLimit) {
+  // A falsy limit (unset before the first fetchPushes) means "no eviction yet".
+  if (!retainedPushLimit || pushList.length <= retainedPushLimit) {
     return {};
   }
 
@@ -242,7 +246,9 @@ export const initialState = {
   oldestPushTimestamp: null,
   allUnclassifiedFailureCount: 0,
   filteredUnclassifiedFailureCount: 0,
-  retainedPushLimit: BASE_RETAINED_PUSHES,
+  // Effective eviction limit; raised to at least getRepoPushCap() (and to any
+  // larger explicit "load more" count) on the first fetchPushes.
+  retainedPushLimit: 0,
 };
 
 export const usePushesStore = create(
@@ -287,14 +293,16 @@ export const usePushesStore = create(
             setFromchange,
             bugSummaryMap,
           );
-          // Explicit push loads (initial load and the "get more pushes" button)
-          // set the high-water mark that polling-driven eviction respects.
+          // The eviction limit is at least the repo cap, and rises with explicit
+          // push loads (initial load and the "get more pushes" button) so those
+          // are never fought.
           const nextPushList = pushResults.pushList || pushList;
           set({
             loadingPushes: false,
             ...pushResults,
             retainedPushLimit: Math.max(
               get().retainedPushLimit,
+              getRepoPushCap(),
               nextPushList.length,
             ),
           });

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -18,6 +18,11 @@ import { notify } from './notificationStore';
 import { clearJobViaUrl, setSelectedJob } from './selectedJobStore';
 
 const DEFAULT_PUSH_COUNT = 10;
+// Upper bound on pushes retained while polling. Generous enough that normal
+// short sessions never evict a push from the initial viewport, small enough to
+// bound memory for a multi-hour tab. Explicit "get more pushes" loads raise the
+// effective limit (see retainedPushLimit) so the user is never fought.
+const BASE_RETAINED_PUSHES = 50;
 const PUSH_POLLING_KEYS = ['tochange', 'enddate', 'revision', 'author'];
 const PUSH_FETCH_KEYS = [...PUSH_POLLING_KEYS, 'fromchange', 'startdate'];
 
@@ -175,6 +180,7 @@ export const initialState = {
   oldestPushTimestamp: null,
   allUnclassifiedFailureCount: 0,
   filteredUnclassifiedFailureCount: 0,
+  retainedPushLimit: BASE_RETAINED_PUSHES,
 };
 
 export const usePushesStore = create(
@@ -219,7 +225,17 @@ export const usePushesStore = create(
             setFromchange,
             bugSummaryMap,
           );
-          set({ loadingPushes: false, ...pushResults });
+          // Explicit push loads (initial load and the "get more pushes" button)
+          // set the high-water mark that polling-driven eviction respects.
+          const nextPushList = pushResults.pushList || pushList;
+          set({
+            loadingPushes: false,
+            ...pushResults,
+            retainedPushLimit: Math.max(
+              get().retainedPushLimit,
+              nextPushList.length,
+            ),
+          });
         } else {
           notify('Error retrieving push data!', 'danger', { sticky: true });
           set({ loadingPushes: false });

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -15,7 +15,12 @@ import { processErrors, getData } from '../../helpers/http';
 import { updateUrlSearch } from '../../helpers/router';
 
 import { notify } from './notificationStore';
-import { clearJobViaUrl, setSelectedJob } from './selectedJobStore';
+import {
+  clearJobViaUrl,
+  setSelectedJob,
+  useSelectedJobStore,
+} from './selectedJobStore';
+import { usePinnedJobsStore } from './pinnedJobsStore';
 
 const DEFAULT_PUSH_COUNT = 10;
 // Upper bound on pushes retained while polling. Generous enough that normal
@@ -101,6 +106,63 @@ const doRecalculateUnclassifiedCounts = (jobMap) => {
   return {
     allUnclassifiedFailureCount,
     filteredUnclassifiedFailureCount,
+  };
+};
+
+// Pushes that must never be evicted: the selected push and any push with a
+// pinned job. Read from the other stores at call time (no circular import).
+const getProtectedPushIds = () => {
+  const ids = new Set();
+  const { selectedJob } = useSelectedJobStore.getState();
+  if (selectedJob) {
+    ids.add(selectedJob.push_id);
+  }
+  const { pinnedJobs } = usePinnedJobsStore.getState();
+  Object.values(pinnedJobs).forEach((job) => ids.add(job.push_id));
+  return ids;
+};
+
+// Bound retained pushes so a long-open, polling tab does not grow unbounded.
+// Keeps the newest `retainedPushLimit` pushes plus any protected push, and
+// prunes the evicted pushes' jobs from jobMap/decisionTaskMap. Returns a
+// partial state object (empty when nothing needs evicting).
+export const enforcePushLimit = (state) => {
+  const { pushList, jobMap, decisionTaskMap, retainedPushLimit } = state;
+  if (pushList.length <= retainedPushLimit) {
+    return {};
+  }
+
+  const protectedIds = getProtectedPushIds();
+  // pushList is sorted newest-first; keep the newest retainedPushLimit, plus
+  // any protected push that would otherwise be evicted.
+  const kept = pushList.slice(0, retainedPushLimit);
+  const protectedOverflow = pushList
+    .slice(retainedPushLimit)
+    .filter((push) => protectedIds.has(push.id));
+  const newPushList = [...kept, ...protectedOverflow];
+  const keptPushIds = new Set(newPushList.map((push) => push.id));
+
+  const newJobMap = {};
+  for (const [id, job] of Object.entries(jobMap)) {
+    if (keptPushIds.has(job.push_id)) {
+      newJobMap[id] = job;
+    }
+  }
+
+  const newDecisionTaskMap = {};
+  for (const [pushId, entry] of Object.entries(decisionTaskMap)) {
+    if (keptPushIds.has(Number(pushId))) {
+      newDecisionTaskMap[pushId] = entry;
+    }
+  }
+
+  return {
+    pushList: newPushList,
+    jobMap: newJobMap,
+    decisionTaskMap: newDecisionTaskMap,
+    oldestPushTimestamp: newPushList[newPushList.length - 1].push_timestamp,
+    ...getRevisionTips(newPushList),
+    ...doRecalculateUnclassifiedCounts(newJobMap),
   };
 };
 


### PR DESCRIPTION
Part 2 of 3 addressing Bug 1499551 (jobs-view memory growth over time). Expanded per team discussion to also bound background-tab lifetime.

## 1. Per-repo rolling push cap

On a watched tree the 60s poll appends pushes and their jobs with no eviction, so `pushList`/`jobMap`/`decisionTaskMap` and the per-`<Push>` job state grow unbounded. Now:

- Rolling cap on retained pushes: **200 for autoland, 100 for other repos** (`getRepoPushCap`).
- Cap-polling-only: the cap is a floor; explicit "get more pushes" loads still raise the limit, so users can browse deeper history. Polling-driven growth is evicted back to the cap (oldest first), pruning those pushes' jobs — which is what reclaims the memory.
- The selected push and any push with a pinned job are never evicted.

## 2. Stop polling forgotten background tabs (idle timeout + keep-alive)

- A tab left in the background (Page Visibility `hidden`) stops the push/job poll after **2 hours** of continuous inactivity. Bringing it back to the foreground resumes polling (with one catch-up poll) and resets the clock.
- A **keep-alive toggle** (a coffee mug) in the jobs-view toolbar extends that window to **12 hours** for a tab you intend to leave open. Per-tab, default off, not persisted.
- Only the push/job poll stops; app-level intervals (deployed-version check, notifications) keep running.

New pieces: `pollControlStore` (per-tab `keepAlive`/`pollingPaused`), `usePollingLifecycle` hook (interval + visibility idle logic, extracted from `PushList` for isolated testing), and `KeepAliveButton`.

## Testing
- Per-repo cap: `getRepoPushCap`, `enforcePushLimit` eviction + selected/pinned protection + jobMap pruning, floor applied on `fetchPushes`, trim after `pollPushes`.
- Idle timeout: `usePollingLifecycle` with fake timers + simulated visibility changes — stops after the limit while hidden, resumes + catch-up on refocus, refocus resets the clock, keep-alive extends to 12h.
- `pollControlStore` and `KeepAliveButton` (toggle + paused indicator).
- Full frontend unit suite passes; lint clean.

Part 3 (#9706) is stacked on this branch.