### PR TITLE
Bug 1499551 - Poll only active pushes to bound poll cost (part 3/3)

### DIFF
--- a/tests/ui/job-view/details/summary/ActionBar_test.jsx
+++ b/tests/ui/job-view/details/summary/ActionBar_test.jsx
@@ -84,4 +84,21 @@ describe('ActionBar expired-task disabling', () => {
 
     expect(JobModel.retrigger).not.toHaveBeenCalled();
   });
+
+  it('marks the push active for polling when a job is retriggered', () => {
+    usePushesStore.setState({
+      ...pushesInitialState,
+      decisionTaskMap: { 1: { id: 'DEC_TASK' } },
+      forcePollPushIds: new Set(),
+    });
+    render(<ActionBar {...baseProps} />);
+
+    window.dispatchEvent(
+      new CustomEvent(thEvents.jobRetrigger, {
+        detail: { job: baseProps.selectedJobFull },
+      }),
+    );
+
+    expect(usePushesStore.getState().forcePollPushIds.has(1)).toBe(true);
+  });
 });

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -332,6 +332,14 @@ describe('Pushes Zustand store', () => {
     expect(state.revisionTips).toEqual(revisionTips.slice(0, 3));
   });
 
+  test('markPushActive adds a push id to forcePollPushIds', () => {
+    usePushesStore.setState({ ...initialState, forcePollPushIds: new Set() });
+
+    usePushesStore.getState().markPushActive(42);
+
+    expect(usePushesStore.getState().forcePollPushIds.has(42)).toBe(true);
+  });
+
   test('should clear the pushList with clearPushes', async () => {
     const push = pushListFixture.results[0];
     usePushesStore.setState({

--- a/tests/ui/job-view/stores/pushes_test.jsx
+++ b/tests/ui/job-view/stores/pushes_test.jsx
@@ -332,6 +332,57 @@ describe('Pushes Zustand store', () => {
     expect(state.revisionTips).toEqual(revisionTips.slice(0, 3));
   });
 
+  test('fetchNewJobs only queries incomplete, forced, or selected pushes', async () => {
+    // push 1: running job (incomplete); push 2: all completed;
+    // push 3: completed but force-flagged active.
+    const pushList = [1, 2, 3].map((id) => ({ id, revision: `rev${id}` }));
+    const jobMap = {
+      10: {
+        id: 10,
+        push_id: 1,
+        state: 'running',
+        last_modified: '2019-08-05T20:00:00',
+      },
+      20: {
+        id: 20,
+        push_id: 2,
+        state: 'completed',
+        last_modified: '2019-08-05T20:00:00',
+      },
+      30: {
+        id: 30,
+        push_id: 3,
+        state: 'completed',
+        last_modified: '2019-08-05T20:00:00',
+      },
+    };
+
+    usePushesStore.setState({
+      ...initialState,
+      pushList,
+      jobMap,
+      forcePollPushIds: new Set([3]),
+    });
+
+    let requestedUrl = '';
+    fetchMock.mock(`begin:${getApiUrl('/jobs/?', repoName)}`, (url) => {
+      requestedUrl = url;
+      return { count: 0, next: null, results: [] };
+    });
+
+    window.location = { search: '', pathname: '/jobs' };
+    await usePushesStore.getState().fetchNewJobs();
+
+    const params = new URLSearchParams(requestedUrl.split('?')[1]);
+    const ids = params
+      .get('push_id__in')
+      .split(',')
+      .map(Number)
+      .sort((a, b) => a - b);
+    // push 2 (all completed, not forced, not selected) is excluded.
+    expect(ids).toEqual([1, 3]);
+  });
+
   test('markPushActive adds a push id to forcePollPushIds', () => {
     usePushesStore.setState({ ...initialState, forcePollPushIds: new Set() });
 

--- a/ui/job-view/details/summary/ActionBar.jsx
+++ b/ui/job-view/details/summary/ActionBar.jsx
@@ -39,7 +39,10 @@ import { pinJob } from '../../../shared/stores/pinnedJobsStore';
 import { notify } from '../../../shared/stores/notificationStore';
 import { getAction } from '../../../helpers/taskcluster';
 import { checkRootUrl } from '../../../taskcluster-auth-callback/constants';
-import { usePushesStore } from '../../../shared/stores/pushesStore';
+import {
+  usePushesStore,
+  markPushActive,
+} from '../../../shared/stores/pushesStore';
 
 import LogUrls from './LogUrls';
 
@@ -143,6 +146,9 @@ class ActionBar extends React.PureComponent {
       return undefined;
     }
 
+    // Creates a new job on this push; keep polling it.
+    markPushActive(selectedJobFull.push_id);
+
     return triggerTask(
       selectedJobFull,
       notify,
@@ -159,6 +165,9 @@ class ActionBar extends React.PureComponent {
     if (taskExpired) {
       return;
     }
+
+    // Creates a new job on this push; keep polling it.
+    markPushActive(selectedJobFull.push_id);
 
     await triggerTask(
       selectedJobFull,
@@ -191,6 +200,10 @@ class ActionBar extends React.PureComponent {
     });
 
     JobModel.retrigger(jobs, currentRepo, notify, 1, decisionTaskMap);
+
+    // Keep polling these pushes for the newly created jobs even if they
+    // otherwise looked complete.
+    jobs.forEach((job) => markPushActive(job.push_id));
   };
 
   backfillJob = async () => {
@@ -207,6 +220,9 @@ class ActionBar extends React.PureComponent {
     }
 
     const { id: decisionTaskId } = decisionTaskMap[selectedJobFull.push_id];
+
+    // Backfill creates new jobs on this push; keep polling it.
+    markPushActive(selectedJobFull.push_id);
 
     TaskclusterModel.load(decisionTaskId, selectedJobFull, currentRepo).then(
       (results) => {
@@ -254,6 +270,9 @@ class ActionBar extends React.PureComponent {
     }
 
     confirmFailure(selectedJobFull, notify, decisionTaskMap, currentRepo);
+
+    // Confirming a failure retriggers the job; keep polling this push.
+    markPushActive(selectedJobFull.push_id);
   };
 
   // Can we backfill? Excludes 'try' repos and tasks whose Taskcluster

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -2,7 +2,6 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import pick from 'lodash/pick';
 import keyBy from 'lodash/keyBy';
-import max from 'lodash/max';
 
 import { parseQueryParams, bugzillaBugsApi } from '../../helpers/url';
 import { getUrlParam, replaceLocation } from '../../helpers/location';
@@ -77,14 +76,42 @@ const getBugSummaryMap = async (bugIds, oldBugSummaryMap) => {
   usePushesStore.setState({ bugSummaryMap: result });
 };
 
-const getLastModifiedJobTime = (jobMap) => {
-  const latest =
-    max(
-      Object.values(jobMap).map((job) => new Date(`${job.last_modified}Z`)),
-    ) || new Date();
+const INCOMPLETE_JOB_STATES = new Set(['pending', 'running']);
 
-  latest.setSeconds(latest.getSeconds() - 3);
-  return latest;
+// Single pass over jobMap: which pushes still have incomplete jobs, and the
+// newest last_modified time (used as the poll's last_modified__gt bound). This
+// replaces a separate max() scan; jobMap size is bounded by enforcePushLimit.
+const scanJobMap = (jobMap) => {
+  const incompletePushIds = new Set();
+  let latest = null;
+  for (const job of Object.values(jobMap)) {
+    if (INCOMPLETE_JOB_STATES.has(job.state)) {
+      incompletePushIds.add(job.push_id);
+    }
+    const modified = new Date(`${job.last_modified}Z`);
+    if (latest === null || modified > latest) {
+      latest = modified;
+    }
+  }
+  const lastModified = latest || new Date();
+  lastModified.setSeconds(lastModified.getSeconds() - 3);
+  return { incompletePushIds, lastModified };
+};
+
+// Pushes worth polling for job updates: incomplete ones, ones re-activated by a
+// local retrigger/backfill, and the currently selected push (so a job you are
+// watching stays live). Completed pushes fall out, shrinking the query.
+const getActivePushIds = (pushList, incompletePushIds, forcePollPushIds) => {
+  const { selectedJob } = useSelectedJobStore.getState();
+  const selectedPushId = selectedJob ? selectedJob.push_id : null;
+  return pushList
+    .map((push) => push.id)
+    .filter(
+      (id) =>
+        incompletePushIds.has(id) ||
+        forcePollPushIds.has(id) ||
+        id === selectedPushId,
+    );
 };
 
 /**
@@ -358,18 +385,38 @@ export const usePushesStore = create(
       },
 
       fetchNewJobs: async () => {
-        const { pushList, jobMap } = get();
+        const { pushList, jobMap, forcePollPushIds } = get();
 
         if (!pushList.length) {
           return;
         }
 
-        const pushIds = pushList.map((push) => push.id);
-        const lastModified = getLastModifiedJobTime(jobMap);
+        const { incompletePushIds, lastModified } = scanJobMap(jobMap);
+        const activePushIds = getActivePushIds(
+          pushList,
+          incompletePushIds,
+          forcePollPushIds,
+        );
+
+        // Drop force flags now covered by incompleteness (rule 1 owns them) or
+        // no longer in the push list, keeping the set small.
+        const pushIdSet = new Set(pushList.map((push) => push.id));
+        const prunedForced = new Set(
+          [...forcePollPushIds].filter(
+            (id) => pushIdSet.has(id) && !incompletePushIds.has(id),
+          ),
+        );
+        if (prunedForced.size !== forcePollPushIds.size) {
+          set({ forcePollPushIds: prunedForced });
+        }
+
+        if (!activePushIds.length) {
+          return;
+        }
 
         const resp = await JobModel.getList(
           {
-            push_id__in: pushIds.join(','),
+            push_id__in: activePushIds.join(','),
             last_modified__gt: lastModified.toISOString().replace('Z', ''),
           },
           { fetchAll: true },

--- a/ui/shared/stores/pushesStore.js
+++ b/ui/shared/stores/pushesStore.js
@@ -255,6 +255,10 @@ export const usePushesStore = create(
   devtools(
     (set, get) => ({
       ...initialState,
+      // Push ids to keep polling even though their jobs look complete, e.g.
+      // after a local retrigger/backfill. Not in initialState so each store
+      // instance gets its own Set (and resets don't share a reference).
+      forcePollPushIds: new Set(),
 
       fetchPushes: async (
         count = DEFAULT_PUSH_COUNT,
@@ -402,7 +406,13 @@ export const usePushesStore = create(
       },
 
       clearPushes: () => {
-        set({ ...initialState });
+        set({ ...initialState, forcePollPushIds: new Set() });
+      },
+
+      markPushActive: (pushId) => {
+        const forcePollPushIds = new Set(get().forcePollPushIds);
+        forcePollPushIds.add(pushId);
+        set({ forcePollPushIds });
       },
 
       setPushes: (pushList, jobMap) => {
@@ -472,3 +482,5 @@ export const updateJobMap = (jobList) =>
   usePushesStore.getState().updateJobMap(jobList);
 export const updateRange = (range) =>
   usePushesStore.getState().updateRange(range);
+export const markPushActive = (pushId) =>
+  usePushesStore.getState().markPushActive(pushId);


### PR DESCRIPTION
Part 3 of 3 addressing Bug 1499551 — the CPU/GC fix. **Stacked on #9705** (base is that branch, not master); review/merge #9705 first.

`fetchNewJobs` previously re-queried every push (`push_id__in`) and rescanned the entire `jobMap` for the newest `last_modified` on every 60s poll, so each cycle did progressively more work — the CPU/GC pegging that gets worse the longer a tab is open.

Changes (`ui/shared/stores/pushesStore.js`, `ui/job-view/details/summary/ActionBar.jsx`):

- A single combined pass over `jobMap` now yields both the set of incomplete pushes and the `last_modified__gt` bound (replacing the separate `max()` scan). Scan size is bounded by the eviction cap from #9705.
- `fetchNewJobs` queries only **active** pushes: incomplete (any pending/running job), force-flagged, or the selected push. Long-completed pushes drop out of the query.
- `markPushActive` re-activates a push when a job on it is retriggered/backfilled/confirmed/profiled from this tab, so newly created jobs are still picked up. The flag self-clears once the push is observed incomplete.

Accepted tradeoff: a completed push retriggered by another user (not this tab) won't refresh until reload. Incomplete pushes and all newly-landing pushes still poll every cycle.

## Testing
- New unit tests: only incomplete/forced/selected pushes are queried; `markPushActive` re-includes a completed push; ActionBar retrigger marks the push active.
- Full frontend unit suite passes; lint clean.