### PR TITLE
Bug 1976760 - Enable android telemetry alerting prototyping.

### DIFF
--- a/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_probe.py
+++ b/tests/perf/auto_perf_sheriffing/telemetry_alerting/test_probe.py
@@ -50,6 +50,14 @@ def metric_info_with_none(base_metric_info):
     return base_metric_info
 
 
+@pytest.fixture
+def mobile_metric_info(base_metric_info):
+    """Metric info for a mobile probe with no monitor config."""
+    base_metric_info["platform"] = "mobile"
+    base_metric_info["data"]["monitor"] = None
+    return base_metric_info
+
+
 class TestTelemetryProbeInitialization:
     def test_initialization_with_alert_true(self, metric_info_with_alert):
         """Test probe initialization with alert=True."""
@@ -94,6 +102,22 @@ class TestTelemetryProbeInitialization:
 
         assert probe.monitor_info["detect_changes"] is False
 
+    def test_initialization_desktop_platform(self, base_metric_info):
+        """Test probe reflects the desktop platform from its metric info."""
+        probe = TelemetryProbe(base_metric_info)
+
+        assert probe.platform == "desktop"
+        assert probe.is_desktop is True
+        assert probe.is_mobile is False
+
+    def test_initialization_mobile_platform(self, mobile_metric_info):
+        """Test probe reflects the mobile platform from its metric info."""
+        probe = TelemetryProbe(mobile_metric_info)
+
+        assert probe.platform == "mobile"
+        assert probe.is_mobile is True
+        assert probe.is_desktop is False
+
 
 class TestTelemetryProbeMonitorInfoSetter:
     def test_monitor_info_dict_with_detect_changes(self, base_metric_info):
@@ -116,6 +140,23 @@ class TestTelemetryProbeMonitorInfoSetter:
 
         assert "must by either a boolean or dictionary" in str(exc_info.value)
         assert "networking_http_channel_page_open_to_first_sent" in str(exc_info.value)
+
+    def test_monitor_info_reassignment_enables_detection_and_emails(self, mobile_metric_info):
+        """Reassigning monitor_info enables detection and email-only notifications."""
+        probe = TelemetryProbe(mobile_metric_info)
+        assert probe.should_detect_changes() is False
+
+        probe.monitor_info = {
+            "detect_changes": True,
+            "alert": False,
+            "notification_emails": ["fake@mozilla"],
+        }
+
+        assert probe.should_detect_changes() is True
+        # alert=False -> emails, never bugs.
+        assert probe.should_email() is True
+        assert probe.should_file_bug() is False
+        assert probe.get_notification_emails() == ["fake@mozilla"]
 
 
 class TestTelemetryProbeChangeDetection:

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -28,6 +28,10 @@ from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe import (
     TelemetryProbe,
     TelemetryProbeValidationError,
 )
+from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
+    ANDROID_ALERT_EMAIL,
+    ANDROID_PROBE_ALLOWLIST,
+)
 from treeherder.perf.exceptions import CannotBackfillError, MaxRuntimeExceededError
 from treeherder.perf.models import (
     BackfillNotificationRecord,
@@ -331,24 +335,34 @@ class Sherlock:
         repository = Repository.objects.get(name="mozilla-central")
         framework = PerformanceFramework.objects.get(name="telemetry")
         for metric_info in metric_definitions:
-            if metric_info["platform"] == "mobile":
-                # Skip mobile detection since it's currently broken
-                continue
-
             try:
                 probe = TelemetryProbe(metric_info)
             except TelemetryProbeValidationError as e:
                 logger.warning(f"Failed probe validation: {str(e)}")
                 continue
 
+            # Force some android probes to be monitored if they aren't already
+            if probe.is_mobile and probe.name in ANDROID_PROBE_ALLOWLIST:
+                probe.monitor_info = {
+                    "detect_changes": True,
+                    "alert": False,
+                    "notification_emails": [ANDROID_ALERT_EMAIL],
+                }
+
             if not probe.should_detect_changes():
                 continue
             probes.setdefault(probe.name, probe)
 
-            logger.info(f"Running detection for {probe.name}")
+            logger.info(f"Running detection for {probe.name} on {probe.platform}")
             cdf_ts_detector = ts_detectors[probe.get_change_detection_technique()]
 
-            for platform in ("Windows",):
+            # Probes can have slightly different defintions between mobile and desktop
+            # so we need to account for that here
+            platforms = ("Windows",)
+            if probe.is_mobile:
+                platforms = ("Android",)
+
+            for platform in platforms:
                 logger.info(f"On Platform {platform}")
 
                 # Create the probe signature now so that we can capture when it was first
@@ -361,7 +375,7 @@ class Sherlock:
                     platform=platform,
                     probe=probe.name,
                     probe_type="Glean",
-                    application="Firefox",
+                    application="Fenix" if probe.is_mobile else "Firefox",
                 )
 
                 try:
@@ -369,7 +383,7 @@ class Sherlock:
                     data = get_metric_table(
                         probe.name,
                         platform,
-                        android=(platform == "Mobile"),
+                        android=probe.is_mobile,
                         use_fog=True,
                         project=project,
                         from_build_date=str(
@@ -559,6 +573,17 @@ class Sherlock:
                     platform_builds[curr_date]["next_build"] = curr_date
 
             prev_date[platform] = curr_date
+
+        # Android (Fenix/GeckoView) nightlies are built from mozilla-central, so
+        # the daily changeset matches the desktop builds. hg.mozilla.org doesn't
+        # expose Android builds in json-firefoxreleases, so reuse the desktop
+        # daily mapping rather than fetching a separate Android build source.
+        for desktop_platform in ("Windows", "Linux", "Darwin"):
+            if desktop_platform in self._buildid_mappings:
+                self._buildid_mappings.setdefault(
+                    "Android", self._buildid_mappings[desktop_platform]
+                )
+                break
 
     def _get_buildid_mappings(self) -> dict:
         try:

--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -31,6 +31,8 @@ from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.probe import (
 from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
     ANDROID_ALERT_EMAIL,
     ANDROID_PROBE_ALLOWLIST,
+    DESKTOP,
+    MOBILE,
 )
 from treeherder.perf.exceptions import CannotBackfillError, MaxRuntimeExceededError
 from treeherder.perf.models import (
@@ -518,8 +520,8 @@ class Sherlock:
 
     def _get_metric_definitions(self) -> list[dict]:
         metric_definition_urls = [
-            ("https://dictionary.telemetry.mozilla.org/data/firefox_desktop/index.json", "desktop"),
-            ("https://dictionary.telemetry.mozilla.org/data/fenix/index.json", "mobile"),
+            ("https://dictionary.telemetry.mozilla.org/data/firefox_desktop/index.json", DESKTOP),
+            ("https://dictionary.telemetry.mozilla.org/data/fenix/index.json", MOBILE),
         ]
 
         merged_metrics = []

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
@@ -7,7 +7,9 @@ from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
     DEFAULT_ALERT_EMAIL,
     DEFAULT_BUGZILLA_INFO,
     DEFAULT_CHANGE_DETECTION,
+    DESKTOP,
     GLEAN_PROBE_INFO,
+    MOBILE,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,11 +72,11 @@ class TelemetryProbe:
 
     @property
     def is_desktop(self):
-        return self.platform == "desktop"
+        return self.platform == DESKTOP
 
     @property
     def is_mobile(self):
-        return self.platform == "mobile"
+        return self.platform == MOBILE
 
     def get_change_detection_technique(self):
         return self.monitor_info.get("change_detection_technique", DEFAULT_CHANGE_DETECTION)

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/probe.py
@@ -64,6 +64,18 @@ class TelemetryProbe:
                 self._time_unit = self._probe_info.get("time_unit", "")
         return self._time_unit
 
+    @property
+    def platform(self):
+        return self.metric_info["platform"]
+
+    @property
+    def is_desktop(self):
+        return self.platform == "desktop"
+
+    @property
+    def is_mobile(self):
+        return self.platform == "mobile"
+
     def get_change_detection_technique(self):
         return self.monitor_info.get("change_detection_technique", DEFAULT_CHANGE_DETECTION)
 

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
@@ -44,6 +44,9 @@ DEFAULT_ALERT_EMAIL = "gmierzwinski@mozilla.com"
 DEFAULT_BUGZILLA_INFO = ("Testing", "Performance")
 EMAIL_LIMIT = 50
 
+DESKTOP = "desktop"
+MOBILE = "mobile"
+
 # Android telemetry alerting is still being rolled out, so it is intentionally
 # limited to a hardcoded allowlist of probes. Alerts for these probes only ever
 # produce emails (never bugs), and those emails are always routed to

--- a/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
+++ b/treeherder/perf/auto_perf_sheriffing/telemetry_alerting/utils.py
@@ -44,6 +44,20 @@ DEFAULT_ALERT_EMAIL = "gmierzwinski@mozilla.com"
 DEFAULT_BUGZILLA_INFO = ("Testing", "Performance")
 EMAIL_LIMIT = 50
 
+# Android telemetry alerting is still being rolled out, so it is intentionally
+# limited to a hardcoded allowlist of probes. Alerts for these probes only ever
+# produce emails (never bugs), and those emails are always routed to
+# ANDROID_ALERT_EMAIL regardless of what the probe definition specifies.
+ANDROID_ALERT_EMAIL = "perf-telemetry-alerts@mozilla.com"
+ANDROID_PROBE_ALLOWLIST = (
+    "perf_largest_contentful_paint",
+    "performance_pageload_fcp",
+    "networking_http_channel_page_open_to_first_sent",
+    "networking_dns_lookup_time",
+    "network_tcp_connection",
+    "dns_native_lookup_time",
+)
+
 
 def get_glean_dictionary_link(telemetry_signature):
     if telemetry_signature.platform in DESKTOP_PLATFORMS:


### PR DESCRIPTION
This patch enables prototyping for android alerting. We start with a small allowlist of probes and force them to email a single email regardless of what monitor settings they may have.