### PR TITLE
Reset bug_status when bug_number changes and log Bugzilla status transitions

### DIFF
--- a/tests/perf/auto_perf_sheriffing/performance_alerting/test_alert_modifier.py
+++ b/tests/perf/auto_perf_sheriffing/performance_alerting/test_alert_modifier.py
@@ -174,7 +174,10 @@ class TestResolutionModifier:
         self,
         mock_bug_searcher_class,
         resolution_modifier_class,
-        test_perf_alert_summary_for_modifier,
+        test_repository,
+        push_stored,
+        test_perf_framework,
+        test_issue_tracker,
     ):
         mock_searcher = Mock()
         mock_searcher.get_today_date.return_value = datetime.now().date()
@@ -183,13 +186,21 @@ class TestResolutionModifier:
         }
         mock_bug_searcher_class.return_value = mock_searcher
 
-        test_perf_alert_summary_for_modifier.bug_number = 12345
-        test_perf_alert_summary_for_modifier.bug_status = PerformanceAlertSummary.BUG_FIXED
-        test_perf_alert_summary_for_modifier.save()
+        summary = PerformanceAlertSummary.objects.create(
+            repository=test_repository,
+            framework=test_perf_framework,
+            prev_push_id=1,
+            push_id=2,
+            manually_created=False,
+            created=datetime.now(),
+            bug_number=12345,
+        )
+        summary.bug_status = PerformanceAlertSummary.BUG_FIXED
+        summary.save()
 
         updates, summaries = resolution_modifier_class.update_alerts()
 
-        assert str(test_perf_alert_summary_for_modifier.id) not in updates
+        assert str(summary.id) not in updates
 
     @patch("treeherder.perf.auto_perf_sheriffing.performance_alerting.alert_modifier.BugSearcher")
     def test_update_alerts_exception_handling(

--- a/tests/perf/test_bug_status.py
+++ b/tests/perf/test_bug_status.py
@@ -1,0 +1,42 @@
+import datetime
+
+from treeherder.perf.models import PerformanceAlertSummary
+
+
+def test_bug_status_resets_on_bug_number_change(
+    test_repository, push_stored, test_perf_framework, test_issue_tracker
+):
+    summary = PerformanceAlertSummary.objects.create(
+        repository=test_repository,
+        framework=test_perf_framework,
+        prev_push_id=1,
+        push_id=2,
+        manually_created=False,
+        created=datetime.datetime.now(),
+        bug_number=12345,
+    )
+    summary.bug_status = PerformanceAlertSummary.BUG_FIXED
+    summary.save()
+
+    summary.bug_number = 54321
+    summary.save()
+    summary.refresh_from_db()
+    assert summary.bug_status is None
+
+
+def test_bug_status_unchanged_when_bug_number_not_changed(
+    test_repository, push_stored, test_perf_framework, test_issue_tracker
+):
+    summary = PerformanceAlertSummary.objects.create(
+        repository=test_repository,
+        framework=test_perf_framework,
+        prev_push_id=1,
+        push_id=2,
+        manually_created=False,
+        created=datetime.datetime.now(),
+        bug_number=12345,
+    )
+    summary.bug_status = PerformanceAlertSummary.BUG_FIXED
+    summary.save()
+    summary.refresh_from_db()
+    assert summary.bug_status == PerformanceAlertSummary.BUG_FIXED

--- a/treeherder/perf/auto_perf_sheriffing/performance_alerting/alert_modifier.py
+++ b/treeherder/perf/auto_perf_sheriffing/performance_alerting/alert_modifier.py
@@ -74,6 +74,10 @@ class ResolutionModifier:
                 continue
             if summary.bug_status == new_bug_status:
                 continue
+            logger.info(
+                f"summary {summary.id}, bug {summary.bug_number}: resolution={bug['resolution']!r}, "
+                f"status={bug['status']!r}, bug_status={summary.bug_status} to {new_bug_status}"
+            )
             updates[str(summary.id)] = {"bug_status": new_bug_status}
             summaries_to_update[str(summary.id)] = summary
 
@@ -122,6 +126,10 @@ class NullBugStatusModifier:
                 new_bug_status = PerformanceAlertSummary.BUG_NEW
             if new_bug_status is None:
                 continue
+            logger.info(
+                f"summary {summary.id}, bug {summary.bug_number}: resolution={bug['resolution']!r}, "
+                f"status={bug['status']!r}, bug_status={summary.bug_status} to {new_bug_status}"
+            )
             updates[str(summary.id)] = {"bug_status": new_bug_status}
             summaries_to_update[str(summary.id)] = summary
 

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -384,10 +384,16 @@ class PerformanceAlertSummaryBase(models.Model):
 
     def save(self, *args, update_fields=None, **kwargs):
         if self.bug_number is not None and self.bug_number != self.__prev_bug_number:
+            has_bug_status = hasattr(self, "bug_status")
             self.bug_updated = datetime.now()
+            if has_bug_status:
+                # always reset bug_status, even if the caller set bug_status in this same save() call
+                self.bug_status = None
 
             if update_fields is not None:
                 update_fields = {"bug_updated"}.union(update_fields)
+                if has_bug_status:
+                    update_fields.add("bug_status")
 
         triage_due = calculate_time_to(self.created, TRIAGE_DAYS)
         # created is initially PerformanceDatum.push_timestamp and due to a potential race condition


### PR DESCRIPTION
Currently, when the bug_number on an AlertSummary is changed, bug_status is not reset. The new bug incorrectly keeps the previous bug's status. This resets bug_status whenever bug_number changes.

Note:
After the status is reset, bug_status is synced by the perf sheriff bot.