### PR TITLE
Fix keyboard shortcuts needing a second press after opening a log or profile

### DIFF
--- a/tests/ui/job-view/KeyboardShortcuts_test.jsx
+++ b/tests/ui/job-view/KeyboardShortcuts_test.jsx
@@ -1,0 +1,67 @@
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+import KeyboardShortcuts from '../../../ui/job-view/KeyboardShortcuts';
+
+// Fire a keydown the way react-hot-keys / hotkeys-js expects (needs keyCode).
+const pressKeyDown = (key, keyCode) =>
+  fireEvent.keyDown(document.body, { key, keyCode, which: keyCode });
+
+const renderShortcuts = (filterModel) =>
+  render(
+    <KeyboardShortcuts
+      filterModel={filterModel}
+      showOnScreenShortcuts={jest.fn()}
+    >
+      <div key="child">child</div>
+    </KeyboardShortcuts>,
+  );
+
+describe('KeyboardShortcuts', () => {
+  afterEach(cleanup);
+
+  // The 'i' shortcut maps to filterModel.toggleInProgress(), which makes it a
+  // convenient probe for whether the handler actually fired.
+  const makeFilterModel = () => ({
+    toggleInProgress: jest.fn(),
+    removeFilter: jest.fn(),
+    toggleClassifiedFailures: jest.fn(),
+    toggleUnscheduledResultStatus: jest.fn(),
+    toggleUnclassifiedFailures: jest.fn(),
+  });
+
+  it('fires a shortcut handler on keydown', () => {
+    const filterModel = makeFilterModel();
+    renderShortcuts(filterModel);
+
+    pressKeyDown('i', 73);
+    fireEvent.keyUp(document.body, { key: 'i', keyCode: 73, which: 73 });
+
+    expect(filterModel.toggleInProgress).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: react-hot-keys keeps an `isKeyDown` latch that is only cleared
+  // by a keyup on document.body. Shortcuts that open a new tab (l, shift+l, g)
+  // steal the keyup, leaving the latch stuck `true` so the NEXT shortcut is
+  // swallowed and must be pressed twice. Losing focus (window blur) must clear
+  // the latch so the next shortcut works on the first press.
+  it('recovers after a lost keyup when the window loses focus', () => {
+    const filterModel = makeFilterModel();
+    renderShortcuts(filterModel);
+
+    // First shortcut fires, but its keyup is "lost" (went to a new tab), so the
+    // latch stays set.
+    pressKeyDown('i', 73);
+    expect(filterModel.toggleInProgress).toHaveBeenCalledTimes(1);
+
+    // Without recovery, this second press is swallowed by the stuck latch.
+    pressKeyDown('i', 73);
+    expect(filterModel.toggleInProgress).toHaveBeenCalledTimes(1);
+
+    // The tab regains focus after the window blurred; the blur handler should
+    // have cleared the latch.
+    fireEvent.blur(window);
+
+    pressKeyDown('i', 73);
+    expect(filterModel.toggleInProgress).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/job-view/KeyboardShortcuts.jsx
+++ b/ui/job-view/KeyboardShortcuts.jsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Hotkeys from 'react-hot-keys';
 
@@ -17,6 +17,19 @@ const handledKeys =
   'b,c,f,ctrl+shift+f,f,g,i,j,k,l,shift+l,n,p,q,r,s,t,u,v,ctrl+shift+u,left,right,space,shift+/,escape,ctrl+enter,ctrl+backspace';
 
 function KeyboardShortcuts({ filterModel, showOnScreenShortcuts, children }) {
+  // react-hot-keys tracks an internal `isKeyDown` latch that it only clears on
+  // a keyup bubbling to document.body. Shortcuts that open a new tab (l, shift+l,
+  // g) steal that keyup, so the latch stays set and the next shortcut is
+  // swallowed (the "have to press it twice" bug). When the window loses focus,
+  // synthesize a keyup so the latch is cleared before focus returns.
+  useEffect(() => {
+    const clearHeldKeys = () => {
+      document.body.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+    };
+    window.addEventListener('blur', clearHeldKeys);
+    return () => window.removeEventListener('blur', clearHeldKeys);
+  }, []);
+
   const clearScreen = useCallback(() => {
     const { pinnedJobs } = usePinnedJobsStore.getState();
     const {


### PR DESCRIPTION
## Problem

Some job-view keyboard shortcuts intermittently have to be pressed **twice** to take effect.

## Root cause

The job view wraps all shortcuts in a single `<Hotkeys>` from `react-hot-keys` (`ui/job-view/KeyboardShortcuts.jsx`). That library keeps an internal `isKeyDown` latch to suppress key-repeat:

- a `keydown` sets the latch `true` (and swallows any further keydown while it's set);
- the latch is only cleared by a `keyup` that bubbles to `document.body`.

Three shortcuts open a **new browser tab/window**, moving focus off the page so their `keyup` is delivered to the new tab and never reaches `document.body`:

| Key | Action |
|-----|--------|
| `l` | logviewer (`target="_blank"` link) |
| `shift+l` | raw log (`target="_blank"` link) |
| `g` | gecko profile (`window.open(url, '_blank')`) |

After one of these, the latch stays stuck `true`, so the **next** shortcut is silently swallowed and must be pressed a second time.

## Fix

Clear the latch when the window loses focus by synthesizing a `keyup` on `document.body`, so the next shortcut fires on the first press. This is general — it also covers alt-tabbing away or any `window.open` while a key is held.

## Testing

- Added `tests/ui/job-view/KeyboardShortcuts_test.jsx`, which reproduces the stuck-latch (second keydown with no intervening keyup is swallowed) and verifies recovery after a `blur`.
- Verified live in the browser against staging data: driving the real `react-hot-keys` instance, keydown #1 fired, keydown #2 (no keyup) was swallowed, and keydown #3 after a `window` blur fired again. Normal press→release→press cycles continue to fire on the first press.
- `PinBoard_test.jsx` (also renders `KeyboardShortcuts`) still passes.