### PR TITLE
Add a new telemetry test command for full run.

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/sherlock.py
+++ b/treeherder/perf/auto_perf_sheriffing/sherlock.py
@@ -307,7 +307,17 @@ class Sherlock:
         alert_manager = PerformanceAlertManager()
         alert_manager.manage_alerts([])
 
-    def telemetry_alert(self):
+    def telemetry_alert(self, probe_filter=None, max_detections=None, platform_filter=None):
+        """Run telemetry change detection and alert management.
+
+        :param probe_filter: If set, only the probe with this name is processed.
+            Useful for locally testing a single probe.
+        :param max_detections: If set, at most this many detections per platform
+            are turned into alerts. Set to 1 to exercise the alert manager with a
+            single detection.
+        :param platform_filter: If set to DESKTOP or MOBILE, only probes for that
+            platform type are processed.
+        """
         if not self._can_run_telemetry():
             return
         if not settings.TELEMETRY_ENABLE_ALERTS:
@@ -337,6 +347,12 @@ class Sherlock:
         repository = Repository.objects.get(name="mozilla-central")
         framework = PerformanceFramework.objects.get(name="telemetry")
         for metric_info in metric_definitions:
+            if probe_filter and metric_info.get("name") != probe_filter:
+                continue
+
+            if platform_filter and metric_info.get("platform") != platform_filter:
+                continue
+
             try:
                 probe = TelemetryProbe(metric_info)
             except TelemetryProbeValidationError as e:
@@ -400,6 +416,9 @@ class Sherlock:
 
                     ts_detector = cdf_ts_detector(timeseries)
                     detections = ts_detector.detect_changes()
+
+                    if max_detections is not None:
+                        detections = detections[:max_detections]
 
                     for detection in detections:
                         # Only get buildids if there might be a detection

--- a/treeherder/perf/management/commands/test_telemetry_alert.py
+++ b/treeherder/perf/management/commands/test_telemetry_alert.py
@@ -8,7 +8,10 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 from treeherder.perf.auto_perf_sheriffing.factories import sherlock_factory
-from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import DESKTOP, MOBILE
+from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import (
+    DESKTOP,
+    MOBILE,
+)
 
 
 class Command(BaseCommand):

--- a/treeherder/perf/management/commands/test_telemetry_alert.py
+++ b/treeherder/perf/management/commands/test_telemetry_alert.py
@@ -1,0 +1,103 @@
+import logging
+import sys
+import traceback
+from contextlib import contextmanager
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from treeherder.perf.auto_perf_sheriffing.factories import sherlock_factory
+from treeherder.perf.auto_perf_sheriffing.telemetry_alerting.utils import DESKTOP, MOBILE
+
+
+class Command(BaseCommand):
+    help = "Runs telemetry alerting with optional specific restrictions in place."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--probe",
+            help=(
+                "Probe name to run detection/alerting for (dots replaced with "
+                "underscores, e.g. 'performance_pageload_fcp'). Defaults to all probes."
+            ),
+        )
+        parser.add_argument(
+            "--platform-type",
+            choices=[DESKTOP, MOBILE],
+            help=(
+                f"Only run probes for this platform type ('{DESKTOP}' or "
+                f"'{MOBILE}'). Defaults to both."
+            ),
+        )
+        parser.add_argument(
+            "--max-detections",
+            type=int,
+            default=1,
+            help="Maximum number of detections to turn into alerts (default: 1).",
+        )
+        parser.add_argument(
+            "--days-to-lookup",
+            type=int,
+            default=1,
+            help="Days back the sherlock instance should look up (default: 1).",
+        )
+        parser.add_argument(
+            "--keep",
+            action="store_true",
+            help="Keep the created DB objects (default: roll back after the run).",
+        )
+
+    @contextmanager
+    def _readable_logging(self):
+        """Temporarily route the `treeherder` logger through a plain console
+        handler so this command's output is human-readable instead of the
+        GCP-structured JSON used in production.
+        """
+        logger = logging.getLogger("treeherder")
+        original_handlers = logger.handlers
+        original_propagate = logger.propagate
+
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setFormatter(
+            logging.Formatter("[%(asctime)s] %(levelname)s [%(name)s:%(lineno)s] %(message)s")
+        )
+        logger.handlers = [handler]
+        logger.propagate = False
+        try:
+            yield
+        finally:
+            logger.handlers = original_handlers
+            logger.propagate = original_propagate
+
+    def handle(self, *args, **options):
+        probe = options["probe"]
+        max_detections = options["max_detections"]
+        platform_type = options["platform_type"]
+
+        self.stdout.write(
+            f"Running telemetry alerting for probe '{probe or 'all'}', "
+            f"platform '{platform_type or 'all'}', with max_detections={max_detections}"
+        )
+
+        sherlock = sherlock_factory(timedelta(days=options["days_to_lookup"]))
+        try:
+            with self._readable_logging(), transaction.atomic():
+                sherlock.telemetry_alert(
+                    probe_filter=probe,
+                    max_detections=max_detections,
+                    platform_filter=platform_type,
+                )
+
+                if not options["keep"]:
+                    self.stdout.write("Rolling back DB changes (use --keep to retain them).")
+                    transaction.set_rollback(True)
+                else:
+                    self.stdout.write("Keeping DB changes.")
+        except Exception as e:
+            self.stderr.write(traceback.format_exc())
+            raise CommandError(
+                f"Failed to run telemetry alerting for '{probe or 'all'}': {e}"
+            ) from e
+
+        self.stdout.write(self.style.SUCCESS("Done."))


### PR DESCRIPTION
This patch adds a new command to run a full telemetry alert run. It adds some extra parameters to the telemetry_alert function to be able to test specific scenarios.