### PR TITLE
Speed up FuzzyJobFinder

### DIFF
--- a/tests/ui/job-view/fuzzy_test.jsx
+++ b/tests/ui/job-view/fuzzy_test.jsx
@@ -103,4 +103,129 @@ describe('FuzzyJobFinder', () => {
       );
     });
   });
+
+  test('Toggling "Use full job list" switches the source list and keeps the search applied', async () => {
+    // Distinct trimmed vs. full lists so the toggle produces an observable
+    // difference (the shared mock uses the same array for both).
+    const filteredList = [
+      { name: 'test-linux64/opt', symbol: 'l', groupsymbol: '' },
+      { name: 'test-macosx64/opt', symbol: 'm', groupsymbol: '' },
+    ];
+    const fullList = [
+      ...filteredList,
+      { name: 'test-linux64/debug', symbol: 'l', groupsymbol: '' },
+      { name: 'test-linux1804-64/opt', symbol: 'l', groupsymbol: '' },
+    ];
+
+    const { getByTitle, getByRole, queryAllByTestId } = await render(
+      <FuzzyJobFinder
+        isOpen={isOpen}
+        toggle={() => {}}
+        jobList={fullList}
+        filteredJobList={filteredList}
+        className="fuzzy-modal"
+        pushId={id}
+        decisionTaskId={decisionTaskId}
+        currentRepo={currentRepo}
+      />,
+    );
+
+    // The trimmed (filtered) list is shown by default.
+    await waitFor(() => {
+      expect(queryAllByTestId('fuzzyList')).toHaveLength(filteredList.length);
+    });
+
+    // Apply a search term; only the linux job in the filtered list matches.
+    const inputElement = getByTitle('Filter the list of runnable jobs');
+    await fireEvent.change(inputElement, { target: { value: 'linux' } });
+    await fireEvent.keyDown(inputElement, { key: 'Enter', code: 'Enter' });
+
+    await waitFor(() => {
+      const names = queryAllByTestId('fuzzyList').map((job) => job.innerHTML);
+      expect(names).toEqual(['test-linux64/opt']);
+    });
+
+    // Toggle to the full list: the source switches AND the search term stays
+    // applied, so we should now see every linux job from the full list.
+    const checkbox = getByRole('checkbox');
+    await fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      const names = queryAllByTestId('fuzzyList')
+        .map((job) => job.innerHTML)
+        .sort();
+      expect(names).toEqual(
+        [
+          'test-linux1804-64/opt',
+          'test-linux64/debug',
+          'test-linux64/opt',
+        ].sort(),
+      );
+    });
+  });
+
+  test('Selecting a job marks it and moves it to the Selected Jobs list', async () => {
+    const { getByText, queryAllByTestId } = await render(testFuzzyJobFinder);
+
+    await waitFor(() => {
+      expect(queryAllByTestId('fuzzyList').length).toBeGreaterThan(0);
+    });
+
+    const targetName = 'addon-tps-xpi';
+    const addSelect = document.querySelector('#addJobsGroup select');
+    const targetOption = queryAllByTestId('fuzzyList').find(
+      (option) => option.textContent === targetName,
+    );
+    targetOption.selected = true;
+    await fireEvent.change(addSelect);
+
+    await fireEvent.click(getByText('Add selected'));
+
+    await waitFor(() => {
+      // The job is marked as selected in the runnable list...
+      const marked = queryAllByTestId('fuzzyList').find(
+        (option) => option.textContent === targetName,
+      );
+      expect(marked.className).toContain('selected');
+
+      // ...and shows up in the Selected Jobs box.
+      const removeSelect = document.querySelector('#removeJobsGroup select');
+      const selectedNames = Array.from(removeSelect.options).map(
+        (option) => option.textContent,
+      );
+      expect(selectedNames).toContain(targetName);
+    });
+  });
+
+  test('Caps the number of rendered jobs and shows how many are hidden', async () => {
+    // More jobs than the render cap (MAX_RENDERED_JOBS = 500) so we can assert
+    // only a slice is mounted while the true total is still reported.
+    const bigList = Array.from({ length: 600 }, (_unused, i) => ({
+      name: `test-job-${String(i).padStart(4, '0')}`,
+      symbol: `j${i}`,
+      groupsymbol: '',
+    }));
+
+    const { getByText, queryAllByTestId } = await render(
+      <FuzzyJobFinder
+        isOpen={isOpen}
+        toggle={() => {}}
+        jobList={bigList}
+        filteredJobList={bigList}
+        className="fuzzy-modal"
+        pushId={id}
+        decisionTaskId={decisionTaskId}
+        currentRepo={currentRepo}
+      />,
+    );
+
+    await waitFor(() => {
+      // Only the first 500 are turned into <option> nodes...
+      expect(queryAllByTestId('fuzzyList')).toHaveLength(500);
+      // ...but the notice reflects the full match count.
+      expect(
+        getByText(/Showing the first 500 of 600 jobs/),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/job-view/pushes/FuzzyJobFinder.jsx
+++ b/ui/job-view/pushes/FuzzyJobFinder.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button,
@@ -17,6 +17,22 @@ import { formatTaskclusterError } from '../../helpers/errorMessage';
 import { sortAlphaNum } from '../../helpers/sort';
 import { notify } from '../../shared/stores/notificationStore';
 
+const FUSE_OPTIONS = {
+  // http://fusejs.io/ describes the options available
+  useExtendedSearch: true,
+  keys: ['name', 'symbol'],
+  threshold: 0.4, // This seems like a good threshold to remove most false matches, lower is stricter
+  matchAllTokens: true,
+  tokenize: true,
+};
+
+// Cap how many <option> nodes we actually render. On firefox repos the
+// runnable list can be tens of thousands of jobs; mounting (and later tearing
+// down) that many DOM nodes freezes the main thread. Rendering only the first
+// slice keeps the modal responsive; the header still shows the true match
+// count, and narrowing the search brings the real matches under the cap.
+const MAX_RENDERED_JOBS = 500;
+
 function FuzzyJobFinder({
   className,
   isOpen,
@@ -27,7 +43,6 @@ function FuzzyJobFinder({
   currentRepo,
 }) {
   const [fuzzySearch, setFuzzySearch] = useState('');
-  const [fuzzyList, setFuzzyList] = useState([]);
   const [selectedList, setSelectedList] = useState([]);
   const [removeDisabled, setRemoveDisabled] = useState(true);
   const [addDisabled, setAddDisabled] = useState(true);
@@ -36,54 +51,55 @@ function FuzzyJobFinder({
   const [addJobsSelected, setAddJobsSelected] = useState([]);
   const [removeJobsSelected, setRemoveJobsSelected] = useState([]);
 
-  // Use refs to access latest state in callbacks without stale closures
-  const useFullListRef = useRef(useFullList);
-  useFullListRef.current = useFullList;
+  // By default we show a trimmed down list of runnable jobs, but there's an
+  // option to show the full list.
+  const currentList = useFullList ? jobList : filteredJobList;
+
+  // Build the Fuse index only when the underlying list changes, instead of
+  // rebuilding it from scratch on every search (expensive with tens of
+  // thousands of runnable tasks).
+  const fuse = useMemo(() => new Fuse(currentList, FUSE_OPTIONS), [currentList]);
 
   /*
-   *  Filter the list of runnable jobs based on the value of this input.
-   *  Only actually do the filtering when `enter` is pressed, as filtering 13K DOM elements is slow...
-   *  If this input is empty when `enter` is pressed, reset back to the full list of runnable jobs.
+   *  The list of runnable jobs to display, derived from the current search term.
+   *  Filtering only happens when `enter` is pressed (which updates `fuzzySearch`)
+   *  rather than on every keystroke, as the fuzzy search is costly over large
+   *  lists. When the search is empty we fall back to the full (filtered) list of
+   *  runnable jobs. Memoized so the search + sort only reruns when the term or
+   *  source list changes, not on every re-render (e.g. selecting an option).
    */
-  const filterJobs = useCallback(
-    (ev) => {
-      // By default we show a trimmed down list of runnable jobs, but there's an option to show the full list
-      const currentList = useFullListRef.current ? jobList : filteredJobList;
+  const fuzzyList = useMemo(() => {
+    const matches = fuzzySearch
+      ? fuse.search(fuzzySearch).map((job) => job.item)
+      : currentList;
+    // Sort a copy.
+    return [...matches].sort(sortAlphaNum);
+  }, [fuse, fuzzySearch, currentList]);
 
-      if (ev && ev.type === 'keydown') {
-        if (ev.key === 'Enter') {
-          const searchValue = ev.target.value;
-          setFuzzySearch(searchValue);
-
-          const options = {
-            // http://fusejs.io/ describes the options available
-            useExtendedSearch: true,
-            keys: ['name', 'symbol'],
-            threshold: 0.4, // This seems like a good threshold to remove most false matches, lower is stricter
-            matchAllTokens: true,
-            tokenize: true,
-          };
-
-          // Always search from the full (or full filtered) list of jobs
-          const fuse = new Fuse(currentList, options);
-
-          setFuzzyList(
-            searchValue
-              ? fuse.search(searchValue).map((job) => job.item)
-              : currentList,
-          );
-        }
-      } else {
-        setFuzzyList(currentList);
-      }
-    },
-    [jobList, filteredJobList],
+  // Only the first slice is turned into DOM nodes (see MAX_RENDERED_JOBS).
+  const visibleJobs = useMemo(
+    () => fuzzyList.slice(0, MAX_RENDERED_JOBS),
+    [fuzzyList],
   );
+
+  const selectedSet = useMemo(() => new Set(selectedList), [selectedList]);
+  const sortedSelectedList = useMemo(
+    () => [...selectedList].sort(sortAlphaNum),
+    [selectedList],
+  );
+
+  const filterJobs = useCallback((ev) => {
+    if (ev && ev.type === 'keydown' && ev.key === 'Enter') {
+      setFuzzySearch(ev.target.value);
+    }
+  }, []);
 
   const resetForm = useCallback(() => {
     setSelectedList([]);
     setRemoveDisabled(true);
     setSubmitDisabled(false);
+    setFuzzySearch('');
+    setUseFullList(false);
   }, []);
 
   const addAllJobs = useCallback(() => {
@@ -132,20 +148,11 @@ function FuzzyJobFinder({
     }
   }, [selectedList, decisionTaskId, currentRepo, notify, toggle]);
 
-  const toggleFullList = useCallback(
-    (evt) => {
-      const { checked } = evt.target;
-      setUseFullList(checked);
-      useFullListRef.current = checked;
-      // Fake enough state to simulate the enter key being pressed in the search box
-      filterJobs({
-        type: 'keydown',
-        key: 'Enter',
-        target: { value: fuzzySearch },
-      });
-    },
-    [fuzzySearch, filterJobs],
-  );
+  const toggleFullList = useCallback((evt) => {
+    // `currentList` (and therefore `fuzzyList`) derives from this state, so the
+    // list re-derives automatically with the current search term applied.
+    setUseFullList(evt.target.checked);
+  }, []);
 
   const updateAddButton = useCallback((evt) => {
     const selectedOptions = Array.from(
@@ -169,7 +176,6 @@ function FuzzyJobFinder({
   return (
     <div>
       <Modal
-        onShow={filterJobs}
         onExited={resetForm}
         size="lg"
         show={isOpen}
@@ -208,14 +214,20 @@ function FuzzyJobFinder({
               Add all
             </Button>
           </div>
+          {fuzzyList.length > MAX_RENDERED_JOBS && (
+            <small className="text-muted">
+              Showing the first {MAX_RENDERED_JOBS} of {fuzzyList.length} jobs.
+              Refine your search to narrow the list.
+            </small>
+          )}
           <InputGroup id="addJobsGroup">
             <Form.Control as="select" multiple onChange={updateAddButton}>
-              {fuzzyList.sort(sortAlphaNum).map((e) => (
+              {visibleJobs.map((e) => (
                 <option
                   data-testid="fuzzyList"
                   title={`${e.name} - ${e.groupsymbol}(${e.symbol})`}
                   key={e.name}
-                  className={selectedList.includes(e.name) ? 'selected' : ''}
+                  className={selectedSet.has(e.name) ? 'selected' : ''}
                 >
                   {e.name}
                 </option>
@@ -243,7 +255,7 @@ function FuzzyJobFinder({
           </div>
           <InputGroup id="removeJobsGroup">
             <Form.Control as="select" multiple onChange={updateRemoveButton}>
-              {selectedList.sort(sortAlphaNum).map((e) => (
+              {sortedSelectedList.map((e) => (
                 <option title={e} key={e}>
                   {e}
                 </option>


### PR DESCRIPTION
Memoize the job list and fuse index, don't sort on every render, and use a set instead of an array to test inclusion.

And more importantly, cap the number of displayed task labels: each one is an <option> DOM node and rendering tens of thousands takes forever, freezing the UI.  Users can use the search box to narrow down the list.