### PR TITLE
Restore visited link color in ReactTable bodies.

### DIFF
--- a/ui/css/treeherder-custom-styles.css
+++ b/ui/css/treeherder-custom-styles.css
@@ -505,6 +505,10 @@ a.btn-outline-dark:hover {
   color: #187c86;
 }
 
+.rt-tbody a:visited {
+  color: purple;
+}
+
 /*
  * Onscreen help
  */


### PR DESCRIPTION
.rt-tbody a and a:visited have equal specificity (0,1,1), so the tie was broken by source order. treeherder-base.css is hoisted ahead of treeherder-custom-styles.css in the bundle (ui/App.jsx statically imports ./userguide/App, which is the first module to pull in base.css), which made the teal .rt-tbody rule win for visited links too.

Adding .rt-tbody a:visited at specificity (0,2,1) restores purple for visited links in the intermittent failures tables and the Perfherder graph table view, while unvisited links keep #187c86. purple (#800080) on the table background is ~8.9:1, so this does not regress the contrast pass that motivated the teal rule.


My motivation for fixing this was the "open log viewer" links on https://treeherder.mozilla.org/intermittent-failures/bugdetails?startday=2026-07-20&endday=2026-07-27&tree=all&bug=2057700 where seeing which failures I already looked at is really useful.