### PR TITLE
Bug 2054039 - Add the option to clear all types of notifications

### DIFF
--- a/ui/shared/NotificationList.jsx
+++ b/ui/shared/NotificationList.jsx
@@ -44,8 +44,18 @@ class NotificationList extends React.Component {
               )}
               {notification.sticky && (
                 <Button
+                  variant="outline-secondary"
                   onClick={() => clearNotification(idx)}
-                  className="close pt-1"
+                  className="close ms-3 pt-1 float-end"
+                >
+                  x
+                </Button>
+              )}
+              {!notification.sticky && (
+                <Button
+                  variant="outline-light"
+                  onClick={() => clearNotification(idx)}
+                  className="close ms-3 pt-1 float-end"
                 >
                   x
                 </Button>


### PR DESCRIPTION
[Bug 2054039 - Add the option to clear all types of notifications](https://bugzilla.mozilla.org/show_bug.cgi?id=2054039)

Now all types of notifications are dismissable, while visually improving the button placement and look.

Before:
<img width="1147" height="158" alt="Screenshot 2026-07-28 at 15 35 21" src="https://github.com/user-attachments/assets/370d8895-8f7b-4318-a18f-72036833c8da" />

After: 
<img width="1147" height="158" alt="image" src="https://github.com/user-attachments/assets/a731e329-23a1-4d47-ac9d-c2fa9a2355b1" />
