### PR TITLE
Show the commits of a Lando landing job while waiting for the push.

### DIFF
--- a/tests/ui/job-view/LandoPush_test.jsx
+++ b/tests/ui/job-view/LandoPush_test.jsx
@@ -1,0 +1,98 @@
+/**
+ * Integration test for the display of a lando landing job that has no push
+ * yet: only the lando instances returning the commits of the landing job get
+ * the push-like display, the other ones keep the plain waiting message.
+ */
+
+import fetchMock from 'fetch-mock';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import { AppRoutes } from '../../../ui/App';
+import reposFixture from '../mock/repositories';
+import { getApiUrl } from '../../../ui/helpers/url';
+import { getProjectUrl } from '../../../ui/helpers/location';
+
+const landoUrl = 'https://lando.moz.tools/landing_jobs/72544';
+const landingJob = {
+  commit_id: '',
+  created_at: '2026-07-28T17:22:11.721Z',
+  error: '',
+  id: 72544,
+  requester: 'fqueze@mozilla.com',
+  status: 'SUBMITTED',
+  repository: 'try',
+  revisions: [
+    {
+      author_email: 'florian@queze.net',
+      author_name: 'Florian Quèze',
+      commit_message: 'Bug 2052432 - Log minidump sizes, r=ahal.',
+      url: 'https://lando.moz.tools/landings/72544#r177716',
+    },
+  ],
+  url: 'https://lando.moz.tools/landings/72544',
+};
+
+const jobsUrl =
+  '/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID=72544';
+
+const renderLandingJob = (job) => {
+  fetchMock.get(landoUrl, job, { overwriteRoutes: true });
+  // The url params are read from the location, not from the router.
+  window.history.pushState({}, '', jobsUrl);
+
+  return render(
+    <MemoryRouter initialEntries={[jobsUrl]}>
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+};
+
+describe('Lando push', () => {
+  beforeAll(() => {
+    // ui/App.jsx sets the favicon on this link.
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'icon');
+    document.querySelector('head').appendChild(link);
+
+    fetchMock.get(
+      'begin:https://treestatus.prod.lando.prod.cloudops.mozgcp.net/trees/',
+      { result: { message_of_the_day: '', reason: '', status: 'open' } },
+    );
+    fetchMock.get(getApiUrl('/repository/'), reposFixture);
+    fetchMock.get(getApiUrl('/performance/framework/'), {});
+    fetchMock.get(getApiUrl('/user/'), []);
+    fetchMock.get('/revision.txt', []);
+    fetchMock.get(getApiUrl('/failureclassification/'), []);
+    fetchMock.get(`begin:${getProjectUrl('/push/?full=true&count=', 'try')}`, {
+      results: [],
+    });
+  });
+
+  afterAll(() => {
+    fetchMock.reset();
+  });
+
+  it('shows the commits when lando returns them', async () => {
+    renderLandingJob(landingJob);
+
+    expect(
+      await screen.findByText(/Log minidump sizes, r=ahal./),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/fqueze@mozilla.com/)).toBeInTheDocument();
+  });
+
+  it('shows the waiting message when lando returns no commit', async () => {
+    renderLandingJob({ ...landingJob, revisions: [] });
+
+    expect(
+      await screen.findByText(/Waiting for push with lando commit ID/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('lando-push')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Lando status is: submitted/),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/tests/ui/job-view/pushes/LandoPush.test.jsx
+++ b/tests/ui/job-view/pushes/LandoPush.test.jsx
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for the LandoPush component, which displays a lando landing job
+ * that has not been turned into a push yet, using the layout of a real push.
+ */
+
+import { render, screen } from '@testing-library/react';
+
+import LandoPush from '../../../../ui/job-view/pushes/LandoPush';
+
+const landoJob = {
+  commit_id: '',
+  created_at: '2026-07-28T17:22:11.721Z',
+  error: '',
+  id: 72544,
+  requester: 'fqueze@mozilla.com',
+  status: 'SUBMITTED',
+  updated_at: '2026-07-28T17:22:11.769Z',
+  repository: 'try',
+  url: 'https://lando.moz.tools/landings/72544',
+  revisions: [
+    {
+      author_email: 'florian@queze.net',
+      author_name: 'Florian Quèze',
+      commit_message:
+        "Bug 2052432 - Log each minidump's name and size, r=ahal.\n\nMore details here.",
+      url: 'https://lando.moz.tools/landings/72544#r177716',
+    },
+    {
+      author_email: 'someone@example.com',
+      author_name: 'Some One',
+      commit_message: 'Fuzzy query=xpcshell linux and windows',
+      url: 'https://lando.moz.tools/landings/72544#r177719',
+    },
+  ],
+};
+
+const renderLandoPush = (overrides = {}) =>
+  render(
+    <LandoPush
+      landoJob={{ ...landoJob, ...overrides }}
+      landoInstance="lando-prod-2025"
+    />,
+  );
+
+describe('LandoPush', () => {
+  it('shows the requester and status', () => {
+    renderLandoPush();
+
+    expect(screen.getByText(/fqueze@mozilla.com/)).toBeInTheDocument();
+    expect(screen.getByText('submitted')).toBeInTheDocument();
+    expect(screen.getByTitle('Loading...')).toBeInTheDocument();
+  });
+
+  it('links the push date to the lando job', () => {
+    const { container } = renderLandoPush();
+
+    expect(container.querySelector('.push-header a')).toHaveAttribute(
+      'href',
+      'https://lando.moz.tools/landings/72544',
+    );
+  });
+
+  it('shows one row per revision, tip first, with only the first line of the commit message', () => {
+    renderLandoPush();
+
+    const revisions = screen.getAllByTestId('revision');
+    expect(revisions).toHaveLength(2);
+    // Lando returns the commits in the opposite order.
+    expect(revisions[0]).toHaveTextContent('Fuzzy query=xpcshell');
+    expect(revisions[1]).toHaveTextContent('Log each minidump');
+    expect(
+      screen.getByText(/Log each minidump's name and size, r=ahal./),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/More details here/)).not.toBeInTheDocument();
+  });
+
+  it('shows no commit hash, as the commits have not landed yet', () => {
+    renderLandoPush();
+
+    expect(screen.queryByText('r177716')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Copy full hash')).not.toBeInTheDocument();
+  });
+
+  it('explains that the jobs are not available yet', () => {
+    renderLandoPush();
+
+    expect(
+      screen.getByText(/hasn't been processed by Lando yet/),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the lando error instead, when there is one', () => {
+    const error = 'hg error in cmd: hg push -r tip\nabort: stream ended';
+    const { container } = renderLandoPush({ status: 'FAILED', error });
+
+    // The line breaks of the raw error output are kept.
+    expect(container.querySelector('.lando-push-error').textContent).toBe(
+      error,
+    );
+    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/hasn't been processed by Lando yet/),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each(['LANDED', 'FAILED', 'CANCELLED'])(
+    'stops spinning once the job is %s',
+    (status) => {
+      renderLandoPush({ status });
+
+      expect(screen.queryByTitle('Loading...')).not.toBeInTheDocument();
+    },
+  );
+
+  it('keeps spinning while the job is still being processed', () => {
+    renderLandoPush({ status: 'IN_PROGRESS' });
+
+    expect(screen.getByText('in progress')).toBeInTheDocument();
+    expect(screen.getByTitle('Loading...')).toBeInTheDocument();
+  });
+});

--- a/tests/ui/job-view/pushes/PushLoadErrors.test.jsx
+++ b/tests/ui/job-view/pushes/PushLoadErrors.test.jsx
@@ -25,9 +25,7 @@ describe('PushLoadErrors', () => {
 
   const renderPushLoadErrors = (props = {}) => {
     const { loadingPushes = false, ...rest } = props;
-    return render(
-      <PushLoadErrors loadingPushes={loadingPushes} {...rest} />,
-    );
+    return render(<PushLoadErrors loadingPushes={loadingPushes} {...rest} />);
   };
 
   describe('loading state', () => {
@@ -118,6 +116,8 @@ describe('PushLoadErrors', () => {
         repoName: 'mozilla-central',
         landoInstance: 'lando-prod',
         landoCommitID: 'L12345',
+        // Older lando instances return no commits for the landing job.
+        landoJob: null,
         landoStatus: 'in_progress',
       });
 
@@ -133,6 +133,7 @@ describe('PushLoadErrors', () => {
         repoName: 'mozilla-central',
         landoInstance: 'lando-prod',
         landoCommitID: 'L12345',
+        landoJob: null,
         landoStatus: 'submitted',
       });
 
@@ -147,11 +148,25 @@ describe('PushLoadErrors', () => {
         repoName: 'mozilla-central',
         landoInstance: 'lando-prod',
         landoCommitID: 'L12345',
+        landoJob: null,
       });
 
       const link = screen.getByRole('link', { name: 'L12345' });
       expect(link).toHaveAttribute('target', '_blank');
       expect(link).toHaveAttribute('title', 'See lando status');
+    });
+
+    it('shows nothing until the lando landing job has been fetched', () => {
+      const { container } = renderPushLoadErrors({
+        currentRepo: createMockRepo(),
+        repoName: 'mozilla-central',
+        landoInstance: 'lando-prod',
+        landoCommitID: 'L12345',
+      });
+
+      expect(
+        container.querySelector('.unknown-message-body'),
+      ).not.toBeInTheDocument();
     });
 
     it('defaults landoStatus to unknown', () => {
@@ -160,6 +175,7 @@ describe('PushLoadErrors', () => {
         repoName: 'mozilla-central',
         landoInstance: 'lando-prod',
         landoCommitID: 'L12345',
+        landoJob: null,
       });
 
       expect(screen.getByText(/Lando status is: unknown/)).toBeInTheDocument();

--- a/ui/css/treeherder-pushes.css
+++ b/ui/css/treeherder-pushes.css
@@ -24,6 +24,20 @@
   padding-right: 10px;
 }
 
+/* A lando push has no collapse icon, so pad by the width of one (0.875rem)
+   plus the pe-3 spacing that follows it, to align with the other pushes. */
+.lando-push-title {
+  padding-left: 1.625rem;
+}
+
+/* Keep the line breaks of the raw error output coming from lando. */
+.lando-push-error {
+  white-space: pre-wrap;
+  font-family: monospace;
+  font-size: 12px;
+  margin-left: 2em;
+}
+
 .push-body-divider {
   margin-left: 34px;
   border-bottom: 1px solid lightgrey;
@@ -118,6 +132,8 @@ fieldset[disabled] .btn-push:hover {
 
 .revision {
   font-size: 12px;
+  /* Same height as the rows that have a clipboard button for the commit hash. */
+  min-height: 23px;
 }
 
 .revision a {

--- a/ui/job-view/App.jsx
+++ b/ui/job-view/App.jsx
@@ -112,6 +112,8 @@ const App = () => {
   const [landoCommitID] = useState(urlParams.get('landoCommitID'));
   const [landoInstance] = useState(urlParams.get('landoInstance'));
   const [landoStatus, setLandoStatus] = useState('unknown');
+  // undefined until the lando landing job has been fetched.
+  const [landoJob, setLandoJob] = useState();
   const [user, setUser] = useState({ isLoggedIn: false, isStaff: false });
   const [filterModel, setFilterModel] = useState(
     () => new FilterModel(navigate, location),
@@ -175,6 +177,8 @@ const App = () => {
     } else {
       const status = data.status ? data.status : 'unknown';
       setLandoStatus(status.toLowerCase());
+      // Only the newer lando instances return the commits of the landing job.
+      setLandoJob(data.revisions?.length ? data : null);
     }
 
     return revisionData;
@@ -435,6 +439,7 @@ const App = () => {
                       landoCommitID={landoCommitID}
                       landoInstance={landoInstance}
                       landoStatus={landoStatus}
+                      landoJob={landoJob}
                       currentRepo={currentRepo}
                       filterModel={filterModel}
                       duplicateJobsVisible={duplicateJobsVisible}

--- a/ui/job-view/pushes/LandoPush.jsx
+++ b/ui/job-view/pushes/LandoPush.jsx
@@ -1,0 +1,130 @@
+import PropTypes from 'prop-types';
+import { Col, Row } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faExternalLinkAlt,
+  faSpinner,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { toDateStr } from '../../helpers/display';
+import { RevisionList } from '../../shared/RevisionList';
+
+// Statuses a landing job will not move out of.
+const FINAL_STATUSES = ['landed', 'failed', 'cancelled'];
+
+// A lando landing job that hasn't been turned into a push yet, displayed with
+// the layout of a real push so that its commits can be read while waiting.
+export default function LandoPush({ landoJob, landoInstance }) {
+  const {
+    id,
+    error,
+    created_at: createdAt,
+    requester,
+    revisions,
+    url,
+  } = landoJob;
+  const status = landoJob.status.toLowerCase().replace(/_/g, ' ');
+
+  // The commits have no hash yet, so they are displayed without one, and their
+  // url is only used as a key. Lando lists them oldest first, while pushes
+  // show the tip revision first.
+  const landoRevisions = revisions
+    .map((revision) => ({
+      revision: revision.url,
+      author: `${revision.author_name} <${revision.author_email}>`,
+      comments: revision.commit_message,
+    }))
+    .reverse();
+
+  const landingJobLink = (
+    <a href={url} target="_blank" rel="noopener noreferrer">
+      {id}
+    </a>
+  );
+
+  return (
+    <div className="push" data-testid="lando-push">
+      <div className="push-header">
+        <div className="push-bar">
+          <span className="push-left">
+            <span className="push-title-left lando-push-title">
+              <span>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  {toDateStr(Date.parse(createdAt) / 1000)}{' '}
+                  <FontAwesomeIcon
+                    icon={faExternalLinkAlt}
+                    className="icon-superscript"
+                  />
+                </a>{' '}
+                - {requester}
+              </span>
+            </span>
+          </span>
+          <span className="push-progress">
+            {status}
+            {!FINAL_STATUSES.includes(status) && (
+              <FontAwesomeIcon
+                icon={faSpinner}
+                pulse
+                className="th-spinner ms-2"
+                title="Loading..."
+              />
+            )}
+          </span>
+          {/* Empty, but its margin aligns the status with the job counts
+              of a real push. */}
+          <span className="push-buttons" />
+        </div>
+      </div>
+      <div className="push-body-divider" />
+      <Row className="push g-1 flex-nowrap ms-5">
+        <Col xs={5}>
+          <RevisionList
+            revisions={landoRevisions}
+            revisionCount={landoRevisions.length}
+            repo={{}}
+            widthClass="mb-3 ms-4"
+            hideCommitSha
+          />
+        </Col>
+        <Col xs={7} className="job-list job-list-pad">
+          {error ? (
+            <>
+              <span className="text-danger">
+                Landing Job {landingJobLink} failed on {landoInstance}:
+              </span>
+              <div className="lando-push-error">{error}</div>
+            </>
+          ) : (
+            <span className="text-muted">
+              This push hasn&apos;t been processed by Lando yet: Landing Job{' '}
+              {landingJobLink} to instance {landoInstance}.
+              <br />
+              Jobs will appear here in a few minutes.
+            </span>
+          )}
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+LandoPush.propTypes = {
+  landoJob: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    status: PropTypes.string.isRequired,
+    error: PropTypes.string,
+    created_at: PropTypes.string.isRequired,
+    requester: PropTypes.string.isRequired,
+    revisions: PropTypes.arrayOf(
+      PropTypes.shape({
+        author_name: PropTypes.string.isRequired,
+        author_email: PropTypes.string.isRequired,
+        commit_message: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  landoInstance: PropTypes.string.isRequired,
+};

--- a/ui/job-view/pushes/PushList.jsx
+++ b/ui/job-view/pushes/PushList.jsx
@@ -48,6 +48,8 @@ function PushList({
   landoInstance = null,
   landoCommitID = null,
   landoStatus = 'unknown',
+  // No default value: undefined means the lando job hasn't been fetched yet.
+  landoJob,
   currentRepo = {},
   pushHealthVisibility,
 }) {
@@ -229,6 +231,7 @@ function PushList({
           landoInstance={landoInstance}
           landoCommitID={landoCommitID}
           landoStatus={landoStatus}
+          landoJob={landoJob}
         />
       )}
       <div className="card card-body get-next">
@@ -261,6 +264,7 @@ PushList.propTypes = {
   landoInstance: PropTypes.string,
   landoCommitID: PropTypes.string,
   landoStatus: PropTypes.string,
+  landoJob: PropTypes.shape({}),
   currentRepo: PropTypes.shape({}),
 };
 

--- a/ui/job-view/pushes/PushLoadErrors.jsx
+++ b/ui/job-view/pushes/PushLoadErrors.jsx
@@ -1,10 +1,11 @@
-
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 import { getAllUrlParams } from '../../helpers/location';
 import { uiJobsUrlBase, getLandoJobsUrl } from '../../helpers/url';
+
+import LandoPush from './LandoPush';
 
 function PushLoadErrors(props) {
   const {
@@ -14,6 +15,7 @@ function PushLoadErrors(props) {
     landoInstance = null,
     landoCommitID = null,
     landoStatus = 'unknown',
+    landoJob,
     repoName,
   } = props;
   const urlParams = getAllUrlParams();
@@ -63,8 +65,13 @@ function PushLoadErrors(props) {
         !revision &&
         landoInstance &&
         landoCommitID &&
+        // Don't show anything until the lando landing job has been fetched.
+        landoJob !== undefined &&
         currentRepo &&
-        currentRepo.url && (
+        currentRepo.url &&
+        (landoJob ? (
+          <LandoPush landoJob={landoJob} landoInstance={landoInstance} />
+        ) : (
           <div className="push-body unknown-message-body">
             <span>
               {landoInstance && landoCommitID && (
@@ -96,14 +103,17 @@ function PushLoadErrors(props) {
               )}
             </span>
           </div>
+        ))}
+      {!loadingPushes &&
+        revision &&
+        !isRevision(revision) &&
+        currentRepo.url && (
+          <div className="push-body unknown-message-body">
+            This is an invalid or unknown revision. Please change it, or click
+            <a href={`${uiJobsUrlBase}?${urlParams.toString()}`}> here</a> to
+            reload the latest revisions from {repoName}.
+          </div>
         )}
-      {!loadingPushes && revision && !isRevision(revision) && currentRepo.url && (
-        <div className="push-body unknown-message-body">
-          This is an invalid or unknown revision. Please change it, or click
-          <a href={`${uiJobsUrlBase}?${urlParams.toString()}`}> here</a> to
-          reload the latest revisions from {repoName}.
-        </div>
-      )}
       {!loadingPushes &&
         !revision &&
         !landoCommitID &&
@@ -154,6 +164,7 @@ PushLoadErrors.propTypes = {
   landoInstance: PropTypes.string,
   landoCommitID: PropTypes.string,
   landoStatus: PropTypes.string,
+  landoJob: PropTypes.shape({}),
 };
 
 export default PushLoadErrors;

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -70,36 +70,38 @@ export class Revision extends React.PureComponent {
       bugSummaryMap,
       commitShaClass = 'commit-sha',
       commentFont = '',
+      hideCommitSha = false,
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
     const { clipboardVisible } = this.state;
     const { name, email } = parseAuthor(author);
-    const commitRevision = revision;
     const commentColor = this.isBackout(comment)
       ? 'text-danger'
       : 'text-secondary';
 
     return (
       <div className="revision d-flex flex-nowrap" data-testid="revision">
-        <span
-          onMouseEnter={() => this.showClipboard(true)}
-          onMouseLeave={() => this.showClipboard(false)}
-          className="pe-1 text-nowrap"
-        >
-          <Clipboard
-            description="full hash"
-            text={commitRevision}
-            visible={clipboardVisible}
-          />
-          <a
-            title={`Open revision ${commitRevision} on ${repo.url}`}
-            href={repo.getRevisionHref(commitRevision)}
-            className={commitShaClass}
+        {!hideCommitSha && (
+          <span
+            onMouseEnter={() => this.showClipboard(true)}
+            onMouseLeave={() => this.showClipboard(false)}
+            className="pe-1 text-nowrap"
           >
-            {commitRevision.substring(0, 12)}
-          </a>
-        </span>
+            <Clipboard
+              description="full hash"
+              text={revision}
+              visible={clipboardVisible}
+            />
+            <a
+              title={`Open revision ${revision} on ${repo.url}`}
+              href={repo.getRevisionHref(revision)}
+              className={commitShaClass}
+            >
+              {revision.substring(0, 12)}
+            </a>
+          </span>
+        )}
         <AuthorInitials title={`${name}: ${email}`} author={name} />
         <OverlayTrigger
           placement="auto"
@@ -146,4 +148,6 @@ Revision.propTypes = {
   }).isRequired,
   commitShaClass: PropTypes.string,
   commentFont: PropTypes.string,
+  // Lando pushes have no commit hash to show or link to yet.
+  hideCommitSha: PropTypes.bool,
 };

--- a/ui/shared/RevisionList.jsx
+++ b/ui/shared/RevisionList.jsx
@@ -18,6 +18,7 @@ export class RevisionList extends React.PureComponent {
       bugSummaryMap,
       commitShaClass = '',
       commentFont = '',
+      hideCommitSha = false,
     } = this.props;
 
     return (
@@ -30,6 +31,7 @@ export class RevisionList extends React.PureComponent {
             bugSummaryMap={bugSummaryMap}
             commitShaClass={commitShaClass}
             commentFont={commentFont}
+            hideCommitSha={hideCommitSha}
           />
         ))}
         {revisionCount > revisions.length && (
@@ -42,12 +44,13 @@ export class RevisionList extends React.PureComponent {
 }
 
 RevisionList.propTypes = {
-  revision: PropTypes.string.isRequired,
+  // Only needed to link to the pushlog when some revisions are not listed.
+  revision: PropTypes.string,
   revisions: PropTypes.arrayOf(
     PropTypes.shape({
       author: PropTypes.string.isRequired,
       comments: PropTypes.string.isRequired,
-      repository_id: PropTypes.number.isRequired,
+      repository_id: PropTypes.number,
       result_set_id: PropTypes.number,
       revision: PropTypes.string.isRequired,
     }),
@@ -59,6 +62,7 @@ RevisionList.propTypes = {
   widthClass: PropTypes.string,
   commitShaClass: PropTypes.string,
   commentFont: PropTypes.string,
+  hideCommitSha: PropTypes.bool,
 };
 
 export function MoreRevisionsLink(props) {


### PR DESCRIPTION
Since https://github.com/mozilla-conduit/lando/pull/1100, the newer Lando instances return the requester, the submission date and the commits of a landing job, so display them with the layout of a real push instead of a one line "Waiting for push with lando commit ID" message.

The commit rows reuse RevisionList, with a new hideCommitSha option as the commits have no hash to show or link to until they have landed.

Instances that don't return commits (and failed requests) still get the previous message; nothing is displayed until the landing job has been fetched, to avoid flashing that message on load.

Before:
<img width="1163" height="579" alt="Screenshot 2026-07-28 at 19-58-07 0 try" src="https://github.com/user-attachments/assets/c9e42479-5afc-4813-b80f-562a445f9010" />

After:
<img width="1165" height="580" alt="Screenshot 2026-07-28 at 22-20-45 0 try" src="https://github.com/user-attachments/assets/db805b62-602a-4564-bff8-eed52dac0862" />
