### PR TITLE
Show the Firefox Profiler link in the failure summary regardless of file extension.

### DIFF
--- a/tests/ui/helpers/logFormatting.test.jsx
+++ b/tests/ui/helpers/logFormatting.test.jsx
@@ -109,6 +109,27 @@ describe('formatLogLineWithLinks', () => {
       ).toBeInTheDocument();
     });
 
+    it('creates link for profile artifacts with other file extensions', () => {
+      const line =
+        'TEST-UNEXPECTED-FAIL | gfx/layers/apz/test/mochitest/test_group_touchevents-6.html | profile uploaded in profile_test_group_touchevents-6-2.html.json';
+      const jobDetails = [
+        {
+          value: 'profile_test_group_touchevents-6-2.html.json',
+          url: 'https://taskcluster.example.com/artifacts/profile_test_group_touchevents-6-2.html.json',
+        },
+      ];
+
+      const result = formatLogLineWithLinks(line, jobDetails, mockJob);
+      const Wrapper = () => <>{result}</>;
+      render(<Wrapper />);
+
+      expect(
+        screen.getByText(
+          'open profile_test_group_touchevents-6-2.html.json in the Firefox Profiler',
+        ),
+      ).toBeInTheDocument();
+    });
+
     it('returns original line when profile artifact not found in jobDetails', () => {
       const line =
         'INFO profile uploaded in profile_other.js.json to TaskCluster';

--- a/ui/helpers/logFormatting.jsx
+++ b/ui/helpers/logFormatting.jsx
@@ -82,7 +82,7 @@ export default function formatLogLineWithLinks(
   }
 
   // Check for profile uploaded
-  const hasProfile = line.match(/profile uploaded in (profile_.*\.js\.json)/);
+  const hasProfile = line.match(/profile uploaded in (profile_\S+)/);
   if (hasProfile) {
     const artifact = jobDetails.find(
       (artifact) => artifact.value === hasProfile[1],


### PR DESCRIPTION
Follow-up to #9565, which relaxed the extension check for the artifact panel but left the failure summary regex requiring a .js.json suffix. Profiles of mochitest plain test failures are named after the test file, eg. profile_test_group_touchevents-6-2.html.json, so their "profile uploaded in" lines were rendered without a profiler link.

Example job where this got in the way: https://treeherder.mozilla.org/jobs?repo=try&selectedTaskRun=RB4ZZPzuSk6RYevnIODyUQ.0&revision=f2ab81b535040f7c1e55adbb88e1d05a8a14d769