### PR TITLE
Add perf-alert keyword to bug instead of comment tag when posting alert comments

### DIFF
--- a/tests/webapp/api/test_bugzilla.py
+++ b/tests/webapp/api/test_bugzilla.py
@@ -248,7 +248,8 @@ def test_create_unauthenticated_bug(client, eleven_jobs_stored, activate_respons
 
 def test_post_comment(client, activate_responses, test_user):
     """
-    test successfully posting a comment to a Bugzilla bug
+    test successfully posting a comment to a Bugzilla bug and tagging it
+    with the perf-alert keyword
     """
 
     def request_callback(request):
@@ -256,14 +257,14 @@ def test_post_comment(client, activate_responses, test_user):
         requestdata = json.loads(request.body)
         requestheaders = request.headers
         assert requestheaders["x-bugzilla-api-key"] == "12345helloworld"
-        assert requestdata["comment"] == "Performance improvement detected."
-        assert requestdata["comment_tags"] == ["perf-alert"]
-        resp_body = {"id": 101}
+        assert requestdata["comment"] == {"body": "Performance improvement detected."}
+        assert requestdata["keywords"] == {"add": ["perf-alert"]}
+        resp_body = {"bugs": [{"id": 323}]}
         return (200, headers, json.dumps(resp_body))
 
     responses.add_callback(
-        responses.POST,
-        "https://thisisnotbugzilla.org/rest/bug/323/comment",
+        responses.PUT,
+        "https://thisisnotbugzilla.org/rest/bug/323",
         callback=request_callback,
         content_type="application/json",
     )
@@ -275,7 +276,7 @@ def test_post_comment(client, activate_responses, test_user):
         {"bug_id": 323, "comment": "Performance improvement detected."},
     )
     assert resp.status_code == 200
-    assert resp.json()["id"] == 101
+    assert resp.json()["id"] == 323
 
 
 def test_post_comment_missing_bug_id(client, activate_responses, test_user):

--- a/treeherder/webapp/api/bugzilla.py
+++ b/treeherder/webapp/api/bugzilla.py
@@ -158,18 +158,18 @@ class BugzillaViewSet(viewsets.ViewSet):
         if not comment:
             return Response({"failure": "comment is required"}, status=HTTP_400_BAD_REQUEST)
 
-        url = f"{settings.BUGFILER_API_URL}/rest/bug/{bug_id}/comment"
+        url = f"{settings.BUGFILER_API_URL}/rest/bug/{bug_id}"
         headers = {
             "x-bugzilla-api-key": settings.PERF_SHERIFF_API_KEY,
             "Accept": "application/json",
         }
         data = {
-            "comment": comment,
-            "comment_tags": ["perf-alert"],
+            "comment": {"body": comment},
+            "keywords": {"add": ["perf-alert"]},
         }
 
         try:
-            response = make_request(url, method="POST", headers=headers, json=data)
+            response = make_request(url, method="PUT", headers=headers, json=data)
         except requests.exceptions.HTTPError as e:
             try:
                 message = e.response.json()["message"]
@@ -177,4 +177,5 @@ class BugzillaViewSet(viewsets.ViewSet):
                 message = e.response.text
             return Response({"failure": message}, status=HTTP_400_BAD_REQUEST)
 
-        return Response({"id": response.json().get("id")})
+        bugs = response.json().get("bugs", [])
+        return Response({"id": bugs[0].get("id") if bugs else None})


### PR DESCRIPTION
This patch adds the `perf-alert` keyword to the bug when posting alert comments, instead of tagging the comment itself with comment_tags.
There's no way to add a keyword via Bugzilla's comment-only API. Instead, I switched to Bugzilla's bug-update API, which can post a comment and update bug fields (like keywords) in the same request.
If you have any questions or suggestions, please let me know.

[0] https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
[1] Test result: https://bugzilla.mozilla.org/show_bug.cgi?id=1982829#c11