### PR TITLE
Show a link to the Phabricator revision of each commit in the push list.

### DIFF
--- a/tests/ui/job-view/revisions_test.jsx
+++ b/tests/ui/job-view/revisions_test.jsx
@@ -150,6 +150,35 @@ describe('Revision item component', () => {
     ).toBeInTheDocument();
   });
 
+  test('links the Phabricator revision of the commit message trailer', () => {
+    const { getByTitle } = render(
+      <Revision
+        repo={repo}
+        revision={{
+          ...revision,
+          comments: `${revision.comments}\n\nDifferential Revision: https://phabricator.services.mozilla.com/D315454\n`,
+        }}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
+
+    expect(
+      getByTitle('Open D315454 on Phabricator').getAttribute('href'),
+    ).toEqual('https://phabricator.services.mozilla.com/D315454');
+  });
+
+  test('shows no Phabricator link for a commit message without the trailer', () => {
+    render(
+      <Revision
+        repo={repo}
+        revision={revision}
+        bugSummaryMap={push.bugSummaryMap}
+      />,
+    );
+
+    expect(document.querySelectorAll('svg.fa-phabricator')).toHaveLength(0);
+  });
+
   test('marks the revision as backed out if the words "Back out" appear in the comments', () => {
     revision.comments =
       'Back out changeset a6e2d96c1274 (bug 1322565) for eslint failure';

--- a/ui/css/treeherder-pushes.css
+++ b/ui/css/treeherder-pushes.css
@@ -137,6 +137,13 @@ fieldset[disabled] .btn-push:hover {
   font-size: inherit; /* Inherit from parent */
 }
 
+/* Wide enough for almost all pairs of initials, so that what follows stays
+   aligned across the commits of a push. */
+.user-push-initials {
+  display: inline-block;
+  min-width: 1.7em;
+}
+
 /*
  * Revision
  */

--- a/ui/shared/Revision.jsx
+++ b/ui/shared/Revision.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUser } from '@fortawesome/free-regular-svg-icons';
+import { faPhabricator } from '@fortawesome/free-brands-svg-icons';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 import { parseAuthor } from '../helpers/revision';
@@ -73,6 +74,10 @@ export class Revision extends React.PureComponent {
     } = this.props;
     const comment = comments.split('\n')[0];
     const bugMatches = comment.match(/-- ([0-9]+)|bug.([0-9]+)/gi);
+    // Only commits that were submitted to Phabricator carry this trailer.
+    const phabricatorMatch = comments.match(
+      /^Differential Revision: (\S+\/(D[0-9]+))\s*$/m,
+    );
     const { clipboardVisible } = this.state;
     const { name, email } = parseAuthor(author);
     const commitRevision = revision;
@@ -101,6 +106,17 @@ export class Revision extends React.PureComponent {
           </a>
         </span>
         <AuthorInitials title={`${name}: ${email}`} author={name} />
+        {phabricatorMatch && (
+          <a
+            className="ms-2"
+            title={`Open ${phabricatorMatch[2]} on Phabricator`}
+            href={phabricatorMatch[1]}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FontAwesomeIcon icon={faPhabricator} />
+          </a>
+        )}
         <OverlayTrigger
           placement="auto"
           overlay={


### PR DESCRIPTION
The Differential Revision trailer of the commit message is already part of the push data, so no additional request is needed to know it.

Give the author initials a minimum width, so that the icons of the commits of a push are aligned.

This is what this looks like on mozilla-central:
<img width="614" height="537" alt="Screenshot 2026-07-31 at 09-47-44 0 mozilla-central" src="https://github.com/user-attachments/assets/f0c2a503-fa0f-42a5-bd34-268500bf6805" />

And this is what it looks like on one of my try pushes:
<img width="563" height="194" alt="Screenshot 2026-07-31 at 09-48-27 1311 try" src="https://github.com/user-attachments/assets/7efdde71-e79e-4761-9de3-0be846bdc710" />

The main motivation for this change is that sometimes after addressing review comments on a patch, I send it to try one last time, and as soon as I see the try results are green, I want to land. For that I need to click the lando link on the phabricator page, and to access the phabricator page I need to either load first the bug, or the hg changeset; both are page loads that take a while. Given the phabricator revision id is included in the commit message that treeherder already parses, it makes sense to make the link accessible with a single click from the jobs view.

Additionally, I recently had a case where I was surprised I didn't get a quick review on a straightforward one line test fix. After a couple days I double checked and noticed I had forgotten to send that patch to phabricator, even though I had included it in all my recent try pushes. The missing icon there would have been immediately noticeable.

