### PR TITLE
Bug 2057561 - Reduce alert lookup time (Fix 1)

### DIFF
--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -798,8 +798,11 @@ export const createGraphData = (
   symbols,
   commonAlerts,
   replicates,
-) =>
-  seriesData.map((series) => {
+) => {
+  const alertByPush = new Map(alertSummaries.map((a) => [a.push_id, a]));
+  const commonByPush = new Map(commonAlerts[0].map((c) => [c.push_id, c]));
+
+  return seriesData.map((series) => {
     const color = colors.pop();
     const symbol = symbols.pop();
     // signature_id, framework_id and repository_name are
@@ -828,11 +831,9 @@ export const createGraphData = (
         z: color ? color[1] : '',
         _z: symbol || ['circle', 'outline'],
         revision: dataPoint.revision,
-        alertSummary: alertSummaries.find(
-          (item) => item.push_id === dataPoint.push_id,
-        ),
+        alertSummary: alertByPush.get(dataPoint.push_id),
         commonAlert: reduceDictToKeys(
-          commonAlerts[0].find((alert) => alert.push_id === dataPoint.push_id),
+          commonByPush.get(dataPoint.push_id),
           ['id', 'status'],
         ),
         signature_id: series.signature_id,
@@ -852,6 +853,7 @@ export const createGraphData = (
       replicates,
     };
   });
+}
 
 /**
  * This function will create a new Map object that holds keys composed by name and platform.


### PR DESCRIPTION
[Bug 2057561 - Improve frontend performance on Graphs View](https://bugzilla.mozilla.org/show_bug.cgi?id=2057561)

Inside series.data.map(...), every datapoint calls alertSummaries.find(...) and commonAlerts[0].find(...). With 5 series × 2,000 points × 50 alerts that's ~500k comparisons. Fix: Build two Maps keyed by push_id once per series before the map, lookups become O(1).

Before:
<img width="464" height="43" alt="Screenshot 2026-07-31 at 15 08 30" src="https://github.com/user-attachments/assets/940483cf-9c9e-489c-8db6-99265107705d" />

After:
<img width="464" height="43" alt="Screenshot 2026-07-31 at 15 13 14" src="https://github.com/user-attachments/assets/a40098e6-1bd3-4229-a253-1d2d209835b6" />
