### PR TITLE
fix: Fix ingest pr

### DIFF
--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -79,3 +79,47 @@ def test_ingest_pr_converts_url_to_pulse_and_calls_loader(monkeypatch):
 
     def mock_process(self, payload, exchange, root_url):
         calls.append((payload, exchange, root_url))
+
+    monkeypatch.setattr(ingest.PushLoader, "process", mock_process)
+
+    pr_url = "https://github.com/mozilla/treeherder/pull/1692/"
+    root_url = "https://firefox-ci-tc.services.mozilla.com"
+
+    ingest.ingest_pr(pr_url, root_url)
+
+    assert len(calls) == 1
+    payload, exchange, actual_root_url = calls[0]
+    assert exchange == "exchange/taskcluster-github/v1/pull-request"
+    assert actual_root_url == root_url
+    assert payload["organization"] == "mozilla"
+    assert payload["repository"] == "treeherder"
+    assert payload["action"] == "synchronize"
+    assert payload["details"]["event.pullNumber"] == "1692"
+    assert payload["details"]["event.base.repo.url"] == "https://github.com/mozilla/treeherder.git"
+    assert payload["details"]["event.head.repo.url"] == "https://github.com/mozilla/treeherder.git"
+
+
+def test_ingest_pr_handles_missing_trailing_slash(monkeypatch):
+    """Test that ingest_pr handles a PR URL without a trailing slash correctly."""
+    calls = []
+
+    def mock_process(self, payload, exchange, root_url):
+        calls.append((payload, exchange, root_url))
+
+    monkeypatch.setattr(ingest.PushLoader, "process", mock_process)
+
+    pr_url = "https://github.com/mozilla/treeherder/pull/1692"
+    root_url = "https://firefox-ci-tc.services.mozilla.com"
+
+    ingest.ingest_pr(pr_url, root_url)
+
+    assert len(calls) == 1
+    payload, exchange, actual_root_url = calls[0]
+    assert exchange == "exchange/taskcluster-github/v1/pull-request"
+    assert actual_root_url == root_url
+    assert payload["organization"] == "mozilla"
+    assert payload["repository"] == "treeherder"
+    assert payload["action"] == "synchronize"
+    assert payload["details"]["event.pullNumber"] == "1692"
+    assert payload["details"]["event.base.repo.url"] == "https://github.com/mozilla/treeherder.git"
+    assert payload["details"]["event.head.repo.url"] == "https://github.com/mozilla/treeherder.git"

--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -71,3 +71,11 @@ def test_query_data_consumes_compare_dict(monkeypatch):
             "id": "C1",
         }
     ]
+
+
+def test_ingest_pr_converts_url_to_pulse_and_calls_loader(monkeypatch):
+    """Test that ingest_pr parses PR URL with trailing slash and triggers PushLoader.process with the correct structure."""
+    calls = []
+
+    def mock_process(self, payload, exchange, root_url):
+        calls.append((payload, exchange, root_url))

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -48,7 +48,7 @@ class Connection:
 
 
 def ingest_pr(pr_url, root_url):
-    if not pr_url.ends_with("/"):
+    if not pr_url.endswith("/"):
         pr_url += "/"
     _, _, _, org, repo, _, pull_number, _ = pr_url.split("/", 7)
     pulse = {


### PR DESCRIPTION
### Change Introduced
Use the correct `endswith` method instead of `ends_with` for ingesting PRs.

### Before Fix
```
root@7073a8b8b5bd:/app# time python manage.py ingest pr --pr-url https://github.com/mozilla-mobile/android-components/pull/4821
/app/treeherder/etl/management/commands/ingest.py:463: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
Traceback (most recent call last):
  File "/app/manage.py", line 16, in <module>
    execute_from_command_line(sys.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 443, in execute_from_command_line
    utility.execute()
    ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/__init__.py", line 437, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/base.py", line 420, in run_from_argv
    self.execute(*args, **cmd_options)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/django/core/management/base.py", line 464, in execute
    output = self.handle(*args, **options)
  File "/app/treeherder/etl/management/commands/ingest.py", line 484, in handle
    ingest_pr(options["prUrl"], root_url)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/treeherder/etl/management/commands/ingest.py", line 51, in ingest_pr
    if not pr_url.ends_with("/"):
           ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'ends_with'. Did you mean: 'endswith'?
```

### After Fix

```
root@7073a8b8b5bd:/app# time python manage.py ingest pr --pr-url https://github.com/mozilla-mobile/android-components/pull/4821
/app/treeherder/etl/management/commands/ingest.py:463: DeprecationWarning: There is no current event loop
  loop = asyncio.get_event_loop()
{"logging.googleapis.com/diagnostic": {"instrumentation_source": [{"name": "python", "version": "3.16.0"}]},"severity": "INFO", "logging.googleapis.com/labels": {"python_logger": "google.cloud.logging_v2.handlers.structured_log"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 151, "file": "/usr/local/lib/python3.13/site-packages/google/cloud/logging_v2/handlers/structured_log.py", "function": "emit_instrumentation_info"}, "httpRequest": {} }
{"message": "Skipping unsupported repo: https://github.com/mozilla-mobile/android-components None","severity": "WARNING", "logging.googleapis.com/labels": {"python_logger": "treeherder.etl.push_loader"}, "logging.googleapis.com/trace": "", "logging.googleapis.com/spanId": "", "logging.googleapis.com/trace_sampled": false, "logging.googleapis.com/sourceLocation": {"line": 43, "file": "/app/treeherder/etl/push_loader.py", "function": "process"}, "httpRequest": {} }

real    0m7.632s
user    0m4.604s
sys     0m0.941s
```

## Testing done
- Tested manually. Results above.
- Added unit tests to prevent regressions.

@gmierz @Archaeopteryx 