### PR TITLE
Bug 2057561 - Caching derived scatter data (Fix 2)

### DIFF
--- a/tests/ui/perfherder/graphs-view/graphs_view_test.jsx
+++ b/tests/ui/perfherder/graphs-view/graphs_view_test.jsx
@@ -733,6 +733,7 @@ describe('Mocked API calls', () => {
 
     expect(infraChangesButton.classList).toContain('active');
 
+    updateStateParams.mockClear();
     fireEvent.click(infraChangesButton);
 
     // Wait for click to process
@@ -758,6 +759,7 @@ describe('Mocked API calls', () => {
 
     expect(commonAlertsButton.classList).not.toContain('active');
 
+    updateStateParams.mockClear();
     fireEvent.click(commonAlertsButton);
 
     // Wait for click to process
@@ -786,6 +788,7 @@ describe('Mocked API calls', () => {
 
   expect(initialDataPointsButton.classList).not.toContain('active');
 
+  updateStateParams.mockClear();
   fireEvent.click(initialDataPointsButton);
 
   await waitFor(() => {
@@ -815,6 +818,7 @@ test("'Highlight initial data points' button can be turned off", async () => {
 
   expect(initialDataPointsButton.classList).toContain('active');
 
+  updateStateParams.mockClear();
   fireEvent.click(initialDataPointsButton);
 
   await waitFor(() => {
@@ -841,6 +845,7 @@ test("'Highlight initial data points' button can be turned off", async () => {
 
     expect(useReplicatesButton.classList).not.toContain('active');
 
+    updateStateParams.mockClear();
     fireEvent.click(useReplicatesButton);
 
     // Wait for click to process
@@ -866,6 +871,7 @@ test("'Highlight initial data points' button can be turned off", async () => {
 
     expect(useReplicatesButton.classList).toContain('active');
 
+    updateStateParams.mockClear();
     fireEvent.click(useReplicatesButton);
 
     // Wait for click to process

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -78,9 +78,6 @@ class GraphsContainer extends React.Component {
       timeRange,
       selectedDataPoint,
     } = this.props;
-    const _scatterPlotData = flatMap(testData, (item) =>
-      item.visible ? item.data : [],
-    );
 
     if (
       prevProps.highlightAlerts !== highlightAlerts ||
@@ -390,6 +387,55 @@ class GraphsContainer extends React.Component {
     return data.reduce((max, p) => (p.y > max ? p.y : max), data[0].y);
   };
 
+  _dataKey = (props) => {
+    const testDataSig = (props.testData || [])
+      .map((t) => `${t.signature_id}:${t.visible}`)
+      .join(',');
+    
+    return `${testDataSig}|${props.timeRange?.value}|${props.changelogData?.length}`;
+  };
+
+  _getMemoizedData = () => {
+    const currentKey = this._dataKey(this.props);
+
+    if (currentKey === this._lastKey) {
+      return {
+        scatterPlotData: this._scatterCache,
+        infraAffectedData: this._infraAffectedCache,
+      };
+    }
+
+    const scatterPlotData = (this.props.testData || []).flatMap((item) =>
+      item.visible ? item.data : [],
+    );
+
+    let rawInfraData = [];
+    const markDataPoints = 5;
+    
+    (this.props.changelogData || []).forEach((data) =>
+      scatterPlotData.some((dataPoint, index) => {
+        const affectedData = dataPoint.x > data.date;
+        if (affectedData) {
+          rawInfraData.push(
+            scatterPlotData.slice(index, index + markDataPoints),
+          );
+        }
+        return affectedData;
+      }),
+    );
+
+    this._scatterCache = scatterPlotData;
+    this._infraAffectedCache = new Set(
+      flatMap(rawInfraData).map((item) => item.revision),
+    );
+    this._lastKey = currentKey;
+
+    return {
+      scatterPlotData: this._scatterCache,
+      infraAffectedData: this._infraAffectedCache,
+    };
+  };
+
   render() {
     const {
       testData = [],
@@ -405,35 +451,17 @@ class GraphsContainer extends React.Component {
     const {
       highlights,
       highlightCommonAlertsData,
-      scatterPlotData,
       zoomDomain,
       width,
     } = this.state;
 
-    let infraAffectedData = [];
-    const markDataPoints = 5;
+    const { scatterPlotData, infraAffectedData } = this._getMemoizedData();
     const hoverDatum = this.state.hoverId
       ? scatterPlotData.find((d) => d?.dataPointId === this.state.hoverId)
       : null;
     const lockedDatum = this.state.lockedId
       ? scatterPlotData.find((d) => d?.dataPointId === this.state.lockedId)
       : null;
-
-    changelogData.forEach((data) =>
-      scatterPlotData.some((dataPoint, index) => {
-        const affectedData = dataPoint.x > data.date;
-        if (affectedData) {
-          infraAffectedData.push(
-            scatterPlotData.slice(index, index + markDataPoints),
-          );
-        }
-        return affectedData;
-      }),
-    );
-
-    infraAffectedData = new Set(
-      flatMap(infraAffectedData).map((item) => item.revision),
-    );
 
     const yAxisLabel = this.computeYAxisLabel();
     const positionedTick = <VictoryLabel dx={-2} />;

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -99,8 +99,14 @@ class GraphsContainer extends React.Component {
       this.addHighlights();
     }
 
-    if (prevProps.testData !== testData || prevProps.changelogData !== changelogData) {
+    if (prevProps.testData !== testData) {
       this.updateGraphs();
+    }
+    
+    if (prevProps.changelogData !== changelogData) {
+      this.setState((state) => ({
+        infraAffectedData: this.computeInfraAffectedData(state.scatterPlotData, changelogData),
+      }));
     }
 
     if (prevProps.timeRange !== timeRange) {

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -102,7 +102,7 @@ class GraphsContainer extends React.Component {
     if (prevProps.testData !== testData) {
       this.updateGraphs();
     }
-    
+
     if (prevProps.changelogData !== changelogData) {
       this.setState((state) => ({
         infraAffectedData: this.computeInfraAffectedData(state.scatterPlotData, changelogData),
@@ -259,7 +259,7 @@ class GraphsContainer extends React.Component {
   };
 
   computeInfraAffectedData = (scatterPlotData, changelogData = []) => {
-      let rawInfraData = [];
+      const rawInfraData = [];
       const markDataPoints = 5;
       
       changelogData.forEach((data) =>

--- a/ui/perfherder/graphs/GraphsContainer.jsx
+++ b/ui/perfherder/graphs/GraphsContainer.jsx
@@ -39,11 +39,21 @@ class GraphsContainer extends React.Component {
     const scatterPlotData = flatMap(testData, (item) =>
       item.visible ? item.data : [],
     );
+    const scatterPlotMap = scatterPlotData.reduce((acc, datum) => {
+      if (datum?.dataPointId != null) acc[datum.dataPointId] = datum;
+      return acc;
+    }, {});
+    const infraAffectedData = this.computeInfraAffectedData(
+      scatterPlotData, 
+      props.changelogData
+    );
     const zoomDomain = this.initZoomDomain(scatterPlotData);
     this.state = {
       highlights: [],
       highlightCommonAlertsData: [],
       scatterPlotData,
+      scatterPlotMap,
+      infraAffectedData,
       zoomDomain,
       width: window.innerWidth,
       hoverId: null,
@@ -75,6 +85,7 @@ class GraphsContainer extends React.Component {
       highlightChangelogData,
       highlightedRevisions,
       testData,
+      changelogData,
       timeRange,
       selectedDataPoint,
     } = this.props;
@@ -88,7 +99,7 @@ class GraphsContainer extends React.Component {
       this.addHighlights();
     }
 
-    if (prevProps.testData !== testData) {
+    if (prevProps.testData !== testData || prevProps.changelogData !== changelogData) {
       this.updateGraphs();
     }
 
@@ -241,11 +252,40 @@ class GraphsContainer extends React.Component {
     }
   };
 
+  computeInfraAffectedData = (scatterPlotData, changelogData = []) => {
+      let rawInfraData = [];
+      const markDataPoints = 5;
+      
+      changelogData.forEach((data) =>
+        scatterPlotData.some((dataPoint, index) => {
+          const affectedData = dataPoint.x > data.date;
+          if (affectedData) {
+            rawInfraData.push(
+              scatterPlotData.slice(index, index + markDataPoints),
+            );
+          }
+          return affectedData;
+        }),
+      );
+
+      return new Set(
+        flatMap(rawInfraData).map((item) => item.revision),
+      );
+    };
+
   updateGraphs = () => {
-    const { testData, updateStateParams, visibilityChanged } = this.props;
+    const { testData, changelogData, updateStateParams, visibilityChanged } = this.props;
     let { zoomDomain } = this.state;
     const scatterPlotData = testData.flatMap((item) =>
       item.visible ? item.data : [],
+    );
+    const scatterPlotMap = scatterPlotData.reduce((acc, datum) => {
+      if (datum?.dataPointId != null) acc[datum.dataPointId] = datum;
+      return acc;
+    }, {});
+    const infraAffectedData = this.computeInfraAffectedData(
+      scatterPlotData, 
+      changelogData
     );
     this.addHighlights();
     this.buildInitialRunsCache();
@@ -254,6 +294,8 @@ class GraphsContainer extends React.Component {
     }
     this.setState({
       scatterPlotData,
+      scatterPlotMap,
+      infraAffectedData,
       zoomDomain,
     });
 
@@ -387,55 +429,6 @@ class GraphsContainer extends React.Component {
     return data.reduce((max, p) => (p.y > max ? p.y : max), data[0].y);
   };
 
-  _dataKey = (props) => {
-    const testDataSig = (props.testData || [])
-      .map((t) => `${t.signature_id}:${t.visible}`)
-      .join(',');
-    
-    return `${testDataSig}|${props.timeRange?.value}|${props.changelogData?.length}`;
-  };
-
-  _getMemoizedData = () => {
-    const currentKey = this._dataKey(this.props);
-
-    if (currentKey === this._lastKey) {
-      return {
-        scatterPlotData: this._scatterCache,
-        infraAffectedData: this._infraAffectedCache,
-      };
-    }
-
-    const scatterPlotData = (this.props.testData || []).flatMap((item) =>
-      item.visible ? item.data : [],
-    );
-
-    let rawInfraData = [];
-    const markDataPoints = 5;
-    
-    (this.props.changelogData || []).forEach((data) =>
-      scatterPlotData.some((dataPoint, index) => {
-        const affectedData = dataPoint.x > data.date;
-        if (affectedData) {
-          rawInfraData.push(
-            scatterPlotData.slice(index, index + markDataPoints),
-          );
-        }
-        return affectedData;
-      }),
-    );
-
-    this._scatterCache = scatterPlotData;
-    this._infraAffectedCache = new Set(
-      flatMap(rawInfraData).map((item) => item.revision),
-    );
-    this._lastKey = currentKey;
-
-    return {
-      scatterPlotData: this._scatterCache,
-      infraAffectedData: this._infraAffectedCache,
-    };
-  };
-
   render() {
     const {
       testData = [],
@@ -453,15 +446,12 @@ class GraphsContainer extends React.Component {
       highlightCommonAlertsData,
       zoomDomain,
       width,
+      scatterPlotData,
+      infraAffectedData,
     } = this.state;
 
-    const { scatterPlotData, infraAffectedData } = this._getMemoizedData();
-    const hoverDatum = this.state.hoverId
-      ? scatterPlotData.find((d) => d?.dataPointId === this.state.hoverId)
-      : null;
-    const lockedDatum = this.state.lockedId
-      ? scatterPlotData.find((d) => d?.dataPointId === this.state.lockedId)
-      : null;
+    const hoverDatum = this.state.hoverId ? this.state.scatterPlotMap[this.state.hoverId] : null;
+    const lockedDatum = this.state.lockedId ? this.state.scatterPlotMap[this.state.lockedId] : null;
 
     const yAxisLabel = this.computeYAxisLabel();
     const positionedTick = <VictoryLabel dx={-2} />;


### PR DESCRIPTION
[Bug 2057561 - Improve frontend performance on Graphs View](https://bugzilla.mozilla.org/show_bug.cgi?id=2057561)

The render method previously executed expensive `flatMap/forEach/slice` chains and O(N) array traversals on every state change, severely bottlenecking performance during graph hover and highlight events.

Fix:
- Shifted `infraAffectedData` computation out of `render`, recalculating it only when `testData` or `changelogData` explicitly change.
- Created an O(1) `scatterPlotMap` to instantly resolve hovered and locked data points, replacing expensive `.find()` lookups.
- Cleaned up unused, heavy array allocations inside `componentDidUpdate`.

Before:
<img width="307" height="25" alt="Screenshot 2026-07-31 at 12 58 42" src="https://github.com/user-attachments/assets/2e14a968-1530-4874-85df-564562a21d0f" />

After:
<img width="307" height="25" alt="Screenshot 2026-07-31 at 13 00 19" src="https://github.com/user-attachments/assets/65b2f632-dd7b-430c-894b-d14920aa629a" />