### PR TITLE
Bug 2057561 - Optimize array mapping and siblings rerenders (Fix 3)

### DIFF
--- a/tests/ui/perfherder/legend_card_test.jsx
+++ b/tests/ui/perfherder/legend_card_test.jsx
@@ -65,12 +65,12 @@ const legendCard = (
   render(
     <LegendCard
       series={series}
-      testData={testData}
+      testDataRef={{ current: testData }}
       frameworks={[{ id: 1, name: 'talos' }]}
       updateState={updateState}
       updateStateParams={updateStateParams}
-      colors={colors}
-      symbols={graphSymbols}
+      colorsRef={{ current: colors }}
+      symbolsRef={{ current: graphSymbols }}
     />,
   );
 

--- a/ui/perfherder/graphs/GraphsView.jsx
+++ b/ui/perfherder/graphs/GraphsView.jsx
@@ -560,7 +560,7 @@ function GraphsView({ projects, frameworks, user }) {
                     >
                       <LegendCard
                         series={series}
-                        testData={testData}
+                        testDataRef={testDataRef}
                         projects={projects}
                         frameworks={frameworks}
                         user={user}
@@ -583,8 +583,8 @@ function GraphsView({ projects, frameworks, user }) {
                             setErrorMessages(state.errorMessages);
                         }}
                         updateStateParams={updateStateParams}
-                        colors={colors}
-                        symbols={symbols}
+                        colorsRef={colorsRef}
+                        symbolsRef={symbolsRef}
                         selectedDataPoint={selectedDataPoint}
                       />
                     </div>

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -27,7 +27,7 @@ const LegendCard = ({
     );
     const item = testData[targetIndex];
     const isVisible = !item.visible;
-    let updatedItem = { ...item };
+    const updatedItem = { ...item };
 
     if (isVisible && newColors.length && newSymbols.length) {
       updatedItem.color = newColors.pop();

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -113,24 +113,46 @@ const LegendCard = ({
     // when removing a test, check to see if the next test in the queue had a color;
     // if it had secondary and was deselected, reset its color and visibility to
     // the removed test's color, otherwise push that color back into the colors list
+
+    const promoteIndex = graphColors.length - 1;
+
     if (
-      newData[graphColors.length - 1] &&
-      newData[graphColors.length - 1].color[0] === 'border-secondary'
+      newData[promoteIndex] &&
+      newData[promoteIndex].color[0] === 'border-secondary'
     ) {
-      newData[graphColors.length - 1].color = series.color;
-      newData[graphColors.length - 1].visible = true;
-      newData[graphColors.length - 1].data = newData[
-        graphColors.length - 1
-      ].data.map((item) => ({
-        ...item,
-        z: series.color[1],
-      }));
-      resetParams(newData);
+      const promoted = newData[promoteIndex];
+      let nextColor;
+      let nextSymbol;
+      const newColors = [...colors];
+      const newSymbols = [...symbols];
+
+      // if the removed test was disabled, its real color/symbol are in the pools.
+      if (series.color[0] === 'border-secondary') {
+        nextColor = newColors.pop();
+        nextSymbol = newSymbols.pop();
+      } else {
+        nextColor = series.color;
+        nextSymbol = series.symbol;
+      }
+
+      newData[promoteIndex] = {
+        ...promoted,
+        color: nextColor,
+        symbol: nextSymbol,
+        visible: true,
+        data: promoted.data.map((item) => ({
+          ...item,
+          z: nextColor[1],
+          _z: nextSymbol,
+        })),
+      };
+      resetParams(newData, newColors, newSymbols);
     } else if (series.color[0] === 'border-secondary') {
       resetParams(newData);
     } else {
-      const newColors = [...colors, ...[series.color]];
-      resetParams(newData, newColors);
+      const newColors = [...colors, series.color];
+      const newSymbols = [...symbols, series.symbol];
+      resetParams(newData, newColors, newSymbols);
     }
   };
 

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -22,7 +22,9 @@ const LegendCard = ({
     const newSymbols = [...symbols];
     const errorMessages = [];
     let updates;
-    const targetIndex = testData.findIndex((item) => item.signature_id === series.signature_id);
+    const targetIndex = testData.findIndex(
+      (item) => item.signature_id === series.signature_id,
+    );
     const item = testData[targetIndex];
     const isVisible = !item.visible;
     let updatedItem = { ...item };
@@ -62,7 +64,7 @@ const LegendCard = ({
         updatedItem,
         ...testData.slice(targetIndex + 1),
       ];
-      
+
       updates = {
         testData: newTestData,
         colors: newColors,
@@ -234,8 +236,10 @@ LegendCard.propTypes = {
 };
 
 const areEqual = (prev, next) =>
-  prev.series.signature_id === next.series.signature_id &&
-  prev.series.visible === next.series.visible &&
-  prev.colors === next.colors;
+  prev.series === next.series &&
+  prev.testData === next.testData &&
+  prev.colors === next.colors &&
+  prev.symbols === next.symbols &&
+  prev.selectedDataPoint === next.selectedDataPoint;
 
 export default React.memo(LegendCard, areEqual);

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -1,4 +1,4 @@
-
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Button, Form, CloseButton } from 'react-bootstrap';
 
@@ -22,42 +22,47 @@ const LegendCard = ({
     const newSymbols = [...symbols];
     const errorMessages = [];
     let updates;
-    const newTestData = [...testData].map((item) => {
-      if (item.signature_id === series.signature_id) {
-        const isVisible = !item.visible;
+    const targetIndex = testData.findIndex((item) => item.signature_id === series.signature_id);
+    const item = testData[targetIndex];
+    const isVisible = !item.visible;
+    let updatedItem = { ...item };
 
-        if (isVisible && newColors.length && newSymbols.length) {
-          item.color = newColors.pop();
-          item.symbol = newSymbols.pop();
-          item.visible = isVisible;
-          item.data = item.data.map((test) => ({
-            ...test,
-            z: item.color[1],
-            _z: item.symbol,
-          }));
-        } else if (!isVisible) {
-          newColors.push(item.color);
-          newSymbols.push(item.symbol);
-          item.color = ['border-secondary', ''];
-          item.symbol = ['circle', 'outline'];
-          item.visible = isVisible;
-          item.data = item.data.map((test) => ({
-            ...test,
-            z: item.color[1],
-            _z: item.symbol,
-          }));
-        } else {
-          errorMessages.push(
-            "The graph supports viewing 6 tests at a time. To select and view a test that isn't currently visible, first deselect a visible test",
-          );
-        }
-      }
-      return item;
-    });
+    if (isVisible && newColors.length && newSymbols.length) {
+      updatedItem.color = newColors.pop();
+      updatedItem.symbol = newSymbols.pop();
+      updatedItem.visible = isVisible;
+      updatedItem.data = item.data.map((test) => ({
+        ...test,
+        z: updatedItem.color[1],
+        _z: updatedItem.symbol,
+      }));
+    } else if (!isVisible) {
+      newColors.push(item.color);
+      newSymbols.push(item.symbol);
+      updatedItem.color = ['border-secondary', ''];
+      updatedItem.symbol = ['circle', 'outline'];
+      updatedItem.visible = isVisible;
+      updatedItem.data = item.data.map((test) => ({
+        ...test,
+        z: updatedItem.color[1],
+        _z: updatedItem.symbol,
+      }));
+    } else {
+      errorMessages.push(
+        "The graph supports viewing 6 tests at a time. To select and view a test that isn't currently visible, first deselect a visible test",
+      );
+    }
 
     if (errorMessages.length) {
       updates = { errorMessages, visibilityChanged: false };
     } else {
+      // rebuild the array by slicing around the updated item
+      const newTestData = [
+        ...testData.slice(0, targetIndex),
+        updatedItem,
+        ...testData.slice(targetIndex + 1),
+      ];
+      
       updates = {
         testData: newTestData,
         colors: newColors,
@@ -228,4 +233,9 @@ LegendCard.propTypes = {
   selectedDataPoint: PropTypes.shape({}),
 };
 
-export default LegendCard;
+const areEqual = (prev, next) =>
+  prev.series.signature_id === next.series.signature_id &&
+  prev.series.visible === next.series.visible &&
+  prev.colors === next.colors;
+
+export default React.memo(LegendCard, areEqual);

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Badge, Button, Form, CloseButton } from 'react-bootstrap';
 
 import { getFrameworkName } from '../perf-helpers/helpers';
-import { graphColors } from '../perf-helpers/constants';
 import { Perfdocs } from '../perf-helpers/perfdocs';
 import GraphIcon from '../../shared/GraphIcon';
 
@@ -110,50 +109,39 @@ const LegendCard = ({
 
     newData.splice(index, 1);
 
-    // when removing a test, check to see if the next test in the queue had a color;
-    // if it had secondary and was deselected, reset its color and visibility to
-    // the removed test's color, otherwise push that color back into the colors list
-
-    const promoteIndex = graphColors.length - 1;
-
-    if (
-      newData[promoteIndex] &&
-      newData[promoteIndex].color[0] === 'border-secondary'
-    ) {
-      const promoted = newData[promoteIndex];
-      let nextColor;
-      let nextSymbol;
-      const newColors = [...colors];
-      const newSymbols = [...symbols];
-
-      // if the removed test was disabled, its real color/symbol are in the pools.
-      if (series.color[0] === 'border-secondary') {
-        nextColor = newColors.pop();
-        nextSymbol = newSymbols.pop();
-      } else {
-        nextColor = series.color;
-        nextSymbol = series.symbol;
-      }
-
-      newData[promoteIndex] = {
-        ...promoted,
-        color: nextColor,
-        symbol: nextSymbol,
-        visible: true,
-        data: promoted.data.map((item) => ({
-          ...item,
-          z: nextColor[1],
-          _z: nextSymbol,
-        })),
-      };
-      resetParams(newData, newColors, newSymbols);
-    } else if (series.color[0] === 'border-secondary') {
+    // removing a disabled test frees nothing, since it never held a
+    // color, just drop it. Removing a visible test frees its
+    // color: promote the first currently-disabled test to take its
+    // place, or return the color/symbol to the pool if none is waiting.
+    if (series.color[0] === 'border-secondary') {
       resetParams(newData);
-    } else {
+      return;
+    }
+
+    const promoteIndex = newData.findIndex(
+      (item) => item.color[0] === 'border-secondary',
+    );
+
+    if (promoteIndex === -1) {
       const newColors = [...colors, series.color];
       const newSymbols = [...symbols, series.symbol];
       resetParams(newData, newColors, newSymbols);
+      return;
     }
+
+    const promoted = newData[promoteIndex];
+    newData[promoteIndex] = {
+      ...promoted,
+      color: series.color,
+      symbol: series.symbol,
+      visible: true,
+      data: promoted.data.map((item) => ({
+        ...item,
+        z: series.color[1],
+        _z: series.symbol,
+      })),
+    };
+    resetParams(newData);
   };
 
   const subtitleStyle = 'p-0 mb-0 border-0 text-secondary text-start';

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -3,27 +3,31 @@ import PropTypes from 'prop-types';
 import { Badge, Button, Form, CloseButton } from 'react-bootstrap';
 
 import { getFrameworkName } from '../perf-helpers/helpers';
+import { graphColors } from '../perf-helpers/constants';
 import { Perfdocs } from '../perf-helpers/perfdocs';
 import GraphIcon from '../../shared/GraphIcon';
 
 const LegendCard = ({
   series,
-  testData = [],
+  testDataRef,
   updateState,
   updateStateParams,
   selectedDataPoint = null,
   frameworks,
-  colors,
-  symbols,
+  colorsRef,
+  symbolsRef,
 }) => {
   const updateSelectedTest = () => {
-    const newColors = [...colors];
-    const newSymbols = [...symbols];
+    const testData = testDataRef.current;
+    const newColors = [...colorsRef.current];
+    const newSymbols = [...symbolsRef.current];
+
     const errorMessages = [];
     let updates;
     const targetIndex = testData.findIndex(
       (item) => item.signature_id === series.signature_id,
     );
+    if (targetIndex === -1) return;
     const item = testData[targetIndex];
     const isVisible = !item.visible;
     const updatedItem = { ...item };
@@ -100,48 +104,51 @@ const LegendCard = ({
   };
 
   const removeTest = () => {
-    const index = testData.indexOf(series);
-    const newData = [...testData];
+    const testData = testDataRef.current;
+    const colors = colorsRef.current;
+    const symbols = symbolsRef.current;
+
+    const index = testData.findIndex(
+      (item) => item.signature_id === series.signature_id
+    );
 
     if (index === -1) {
       return;
     }
 
+    const newData = [...testData];
+
     newData.splice(index, 1);
 
-    // removing a disabled test frees nothing, since it never held a
-    // color, just drop it. Removing a visible test frees its
-    // color: promote the first currently-disabled test to take its
-    // place, or return the color/symbol to the pool if none is waiting.
-    if (series.color[0] === 'border-secondary') {
+    // promote the test that just shifted into the maximum visibility slot.
+    // this ignores user-deselected tests earlier in the queue and 
+    // strictly targets the next auto-queued test that was forced hidden.
+    const promoteTargetIndex = graphColors.length - 1;
+
+    if (
+      newData[promoteTargetIndex] &&
+      newData[promoteTargetIndex].color[0] === 'border-secondary'
+    ) {
+      const promoted = newData[promoteTargetIndex];
+      newData[promoteTargetIndex] = {
+        ...promoted,
+        color: series.color,
+        symbol: series.symbol,
+        visible: true,
+        data: promoted.data.map((item) => ({
+          ...item,
+          z: series.color[1],
+          _z: series.symbol,
+        })),
+      };
       resetParams(newData);
-      return;
-    }
-
-    const promoteIndex = newData.findIndex(
-      (item) => item.color[0] === 'border-secondary',
-    );
-
-    if (promoteIndex === -1) {
+    } else if (series.color[0] === 'border-secondary') {
+      resetParams(newData);
+    } else {
       const newColors = [...colors, series.color];
       const newSymbols = [...symbols, series.symbol];
       resetParams(newData, newColors, newSymbols);
-      return;
     }
-
-    const promoted = newData[promoteIndex];
-    newData[promoteIndex] = {
-      ...promoted,
-      color: series.color,
-      symbol: series.symbol,
-      visible: true,
-      data: promoted.data.map((item) => ({
-        ...item,
-        z: series.color[1],
-        _z: series.symbol,
-      })),
-    };
-    resetParams(newData);
   };
 
   const subtitleStyle = 'p-0 mb-0 border-0 text-secondary text-start';
@@ -235,21 +242,23 @@ const LegendCard = ({
 };
 
 LegendCard.propTypes = {
-  series: PropTypes.PropTypes.shape({
+  series: PropTypes.shape({
     visible: PropTypes.bool,
   }).isRequired,
   updateState: PropTypes.func.isRequired,
-  testData: PropTypes.arrayOf(PropTypes.shape({})),
   updateStateParams: PropTypes.func.isRequired,
-  colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)).isRequired,
-  selectedDataPoint: PropTypes.shape({}),
-};
+  testDataRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
+  colorsRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
+  symbolsRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
+  selectedDataPoint: PropTypes.shape({}),};
 
-const areEqual = (prev, next) =>
-  prev.series === next.series &&
-  prev.testData === next.testData &&
-  prev.colors === next.colors &&
-  prev.symbols === next.symbols &&
-  prev.selectedDataPoint === next.selectedDataPoint;
+const areEqual = (prev, next) => {
+  const seriesEqual = prev.series === next.series;
+  
+  const prevWasSelected = prev.selectedDataPoint?.signature_id === prev.series.signature_id;
+  const nextIsSelected = next.selectedDataPoint?.signature_id === next.series.signature_id;
+
+  return seriesEqual && prevWasSelected === nextIsSelected && prev.frameworks === next.frameworks;
+};
 
 export default React.memo(LegendCard, areEqual);

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -36,6 +36,7 @@ const LegendCard = ({
       updatedItem.color = newColors.pop();
       updatedItem.symbol = newSymbols.pop();
       updatedItem.visible = isVisible;
+      updatedItem.queued = false;
       updatedItem.data = item.data.map((test) => ({
         ...test,
         z: updatedItem.color[1],
@@ -47,6 +48,7 @@ const LegendCard = ({
       updatedItem.color = ['border-secondary', ''];
       updatedItem.symbol = ['circle', 'outline'];
       updatedItem.visible = isVisible;
+      updatedItem.queued = false;
       updatedItem.data = item.data.map((test) => ({
         ...test,
         z: updatedItem.color[1],
@@ -120,21 +122,23 @@ const LegendCard = ({
 
     newData.splice(index, 1);
 
-    // promote the test that just shifted into the maximum visibility slot.
-    // this ignores user-deselected tests earlier in the queue and 
-    // strictly targets the next auto-queued test that was forced hidden.
-    const promoteTargetIndex = graphColors.length - 1;
-
-    if (
-      newData[promoteTargetIndex] &&
-      newData[promoteTargetIndex].color[0] === 'border-secondary'
-    ) {
-      const promoted = newData[promoteTargetIndex];
-      newData[promoteTargetIndex] = {
+      // Removing a hidden test frees no color slot → just drop it.
+    if (series.color[0] === 'border-secondary') {
+      resetParams(newData);
+      return;
+    }
+    // A visible test was removed → promote the next auto-queued test (one that
+    // was force-hidden only because the palette was exhausted). Tests the user
+    // deliberately hid are queued:false and are never auto-promoted.
+    const promoteIndex = newData.findIndex((item) => item.queued);
+    if (promoteIndex !== -1) {
+      const promoted = newData[promoteIndex];
+      newData[promoteIndex] = {
         ...promoted,
         color: series.color,
         symbol: series.symbol,
         visible: true,
+        queued: false,
         data: promoted.data.map((item) => ({
           ...item,
           z: series.color[1],
@@ -142,13 +146,12 @@ const LegendCard = ({
         })),
       };
       resetParams(newData);
-    } else if (series.color[0] === 'border-secondary') {
-      resetParams(newData);
-    } else {
-      const newColors = [...colors, series.color];
-      const newSymbols = [...symbols, series.symbol];
-      resetParams(newData, newColors, newSymbols);
+      return;
     }
+    // No auto-queued test waiting → return the freed color/symbol to the pool.
+    const newColors = [...colors, series.color];
+    const newSymbols = [...symbols, series.symbol];
+    resetParams(newData, newColors, newSymbols);
   };
 
   const subtitleStyle = 'p-0 mb-0 border-0 text-secondary text-start';

--- a/ui/perfherder/graphs/LegendCard.jsx
+++ b/ui/perfherder/graphs/LegendCard.jsx
@@ -122,7 +122,7 @@ const LegendCard = ({
 
     newData.splice(index, 1);
 
-      // Removing a hidden test frees no color slot → just drop it.
+    // Removing a hidden test frees no color slot → just drop it.
     if (series.color[0] === 'border-secondary') {
       resetParams(newData);
       return;
@@ -172,9 +172,8 @@ const LegendCard = ({
       <div className={`${series.color[0]} graph-legend-card p-3`}>
         <Button
           variant="outline-link"
-          className={`p-0 mb-0 pointer border-0 ${
-            series.visible ? series.color[0] : 'text-muted'
-          } text-start`}
+          className={`p-0 mb-0 pointer border-0 ${series.visible ? series.color[0] : 'text-muted'
+            } text-start`}
           onClick={() => addTestData('addRelatedConfigs')}
           title="Add related configurations"
         >
@@ -223,12 +222,10 @@ const LegendCard = ({
           </Button>
         )}
         <Badge> {framework} </Badge>
-        <div className="small">{`should_alert: ${
-          series.shouldAlert !== false
-        }`}</div>
-        <div className="small">{`alert_change_type: ${
-          series.alertChangeType === 1 ? 'absolute' : 'percentage'
-        }`}</div>
+        <div className="small">{`should_alert: ${series.shouldAlert !== false
+          }`}</div>
+        <div className="small">{`alert_change_type: ${series.alertChangeType === 1 ? 'absolute' : 'percentage'
+          }`}</div>
         <div className="small">{`alert_threshold: ${series.alertThreshold}`}</div>
         <div className="small">{`${series.signatureHash.slice(0, 16)}...`}</div>
       </div>
@@ -253,11 +250,12 @@ LegendCard.propTypes = {
   testDataRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
   colorsRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
   symbolsRef: PropTypes.shape({ current: PropTypes.array }).isRequired,
-  selectedDataPoint: PropTypes.shape({}),};
+  selectedDataPoint: PropTypes.shape({}),
+};
 
 const areEqual = (prev, next) => {
   const seriesEqual = prev.series === next.series;
-  
+
   const prevWasSelected = prev.selectedDataPoint?.signature_id === prev.series.signature_id;
   const nextIsSelected = next.selectedDataPoint?.signature_id === next.series.signature_id;
 

--- a/ui/perfherder/perf-helpers/helpers.js
+++ b/ui/perfherder/perf-helpers/helpers.js
@@ -810,6 +810,7 @@ export const createGraphData = (
       color: color || ['border-secondary', ''],
       symbol: symbol || ['circle', 'outline'],
       visible: Boolean(color),
+      queued: !color,
       name: series.name,
       suite: series.suite,
       signature_id: series.signature_id,


### PR DESCRIPTION
[Bug 2057561 - Improve frontend performance on Graphs View](https://bugzilla.mozilla.org/show_bug.cgi?id=2057561)

Toggling the visibility of a single series unnecessarily maps over the entire testData array and triggers expensive re-renders for all sibling LegendCard components.

Fix: 
- Wrap LegendCard in React.memo with a custom comparator on series.signature_id + series.visible.
- Refactor the updateSelectedTest visibility-toggle handler to bypass the full-array .map(). It now performs an O(1) immutable single-item update by finding the target index, cloning the specific item, and rebuilding the array using slice.