### PR TITLE
Bug 2035204 - Prevent creation of duplicate AlertSummary rows for the same push

### DIFF
--- a/tests/perfalert/test_alerts.py
+++ b/tests/perfalert/test_alerts.py
@@ -440,3 +440,105 @@ def test_alert_emails(
                 for call_arg in mocked_email_client.email.call_args_list
             ]
         )
+
+
+def _generate_regression(test_repository, signature, base_time, interval, gap=False):
+    # gap=True skips the push right before the regression, so its detected prev_push is one earlier.
+    before = int(interval / 2) - (1 if gap else 0)
+    _generate_performance_data(test_repository, signature, base_time, 1, 0.5, before)
+    _generate_performance_data(
+        test_repository, signature, base_time, int(interval / 2) + 1, 1.0, int(interval / 2)
+    )
+
+
+def test_merges_summary_and_widens_prev_push(
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+    test_perf_signature_2,
+    mock_deviance,
+):
+    # signature 2 has a gap right before the regression, so it detects an
+    # earlier prev push than signature 1 for the same push.
+    base_time = time.time()
+    interval = 30
+
+    _generate_regression(test_repository, test_perf_signature, base_time, interval)
+    generate_new_alerts_in_series(test_perf_signature)
+    summary = PerformanceAlertSummary.objects.get()
+    assert summary.prev_push_id == int(interval / 2)
+
+    _generate_regression(test_repository, test_perf_signature_2, base_time, interval, gap=True)
+    generate_new_alerts_in_series(test_perf_signature_2)
+
+    assert PerformanceAlertSummary.objects.count() == 1
+    assert PerformanceAlert.objects.count() == 2
+    assert set(PerformanceAlert.objects.values_list("summary_id", flat=True)) == {summary.id}
+    summary.refresh_from_db()
+    assert summary.prev_push_id == int(interval / 2) - 1
+
+
+def test_does_not_narrow_prev_push(
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+    test_perf_signature_2,
+    mock_deviance,
+):
+    # signature 1 has the gap this time, so its prev push is already the
+    # earliest; signature 2's later prev push must not narrow it.
+    base_time = time.time()
+    interval = 30
+
+    _generate_regression(test_repository, test_perf_signature, base_time, interval, gap=True)
+    generate_new_alerts_in_series(test_perf_signature)
+    summary = PerformanceAlertSummary.objects.get()
+    assert summary.prev_push_id == int(interval / 2) - 1
+
+    _generate_regression(test_repository, test_perf_signature_2, base_time, interval)
+    generate_new_alerts_in_series(test_perf_signature_2)
+
+    summary.refresh_from_db()
+    assert summary.prev_push_id == int(interval / 2) - 1
+
+
+def test_manually_created_summary_keeps_prev_push(
+    test_repository,
+    test_issue_tracker,
+    failure_classifications,
+    generic_reference_data,
+    test_perf_signature,
+    test_perf_signature_2,
+    mock_deviance,
+):
+    base_time = time.time()
+    interval = 30
+
+    _generate_regression(test_repository, test_perf_signature, base_time, interval)
+    push = Push.objects.get(repository=test_repository, revision=f"1234abcd{int(interval / 2) + 1}")
+    prev_push = Push.objects.get(
+        repository=test_repository, revision=f"1234abcd{int(interval / 2)}"
+    )
+    summary = PerformanceAlertSummary.objects.create(
+        repository=test_repository,
+        framework=test_perf_signature.framework,
+        push_id=push.id,
+        prev_push_id=prev_push.id,
+        sheriffed=True,
+        manually_created=True,
+        created=datetime.datetime.now(),
+    )
+
+    # signature 2's gap would otherwise widen prev_push, but this summary
+    # was manually created, so it must be left untouched.
+    _generate_regression(test_repository, test_perf_signature_2, base_time, interval, gap=True)
+    generate_new_alerts_in_series(test_perf_signature_2)
+
+    assert PerformanceAlertSummary.objects.count() == 1
+    assert PerformanceAlert.objects.filter(summary=summary).count() == 1
+    summary.refresh_from_db()
+    assert summary.prev_push_id == prev_push.id

--- a/treeherder/perf/alerts.py
+++ b/treeherder/perf/alerts.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db import transaction
 from django.db.models import Exists, OuterRef, Subquery
 
+from treeherder.model.models import Push
 from treeherder.perf.email import AlertNotificationWriter
 from treeherder.perf.methods.CramerVonMisesDetector import CramerVonMisesDetector
 from treeherder.perf.methods.KolmogorovSmirnovDetector import KolmogorovSmirnovDetector
@@ -189,17 +190,48 @@ def generate_new_alerts_in_series(signature):
                 ):
                     continue
 
-                summary, _ = PerformanceAlertSummary.objects.get_or_create(
-                    repository=signature.repository,
-                    framework=signature.framework,
-                    push_id=cur.push_id,
-                    prev_push_id=prev.push_id,
-                    sheriffed=not signature.monitor,
-                    defaults={
-                        "manually_created": False,
-                        "created": datetime.utcfromtimestamp(cur.push_timestamp),
-                    },
+                # Lock the push row first. generate_alerts() runs per-signature as separate
+                # Celery tasks (concurrency=3), so two signatures regressing on the same push
+                # can otherwise race here and each create their own duplicate summary below.
+                Push.objects.select_for_update().get(id=cur.push_id)
+
+                # Duplicate summaries may already exist for this push (pre-merge legacy data),
+                # so get() would raise MultipleObjectsReturned here. Use filter() and take
+                # the earliest one instead of crashing.
+                summary = (
+                    PerformanceAlertSummary.objects.select_related("prev_push")
+                    .filter(
+                        repository=signature.repository,
+                        framework=signature.framework,
+                        push_id=cur.push_id,
+                        sheriffed=not signature.monitor,
+                    )
+                    .order_by("created", "id")
+                    .first()
                 )
+                is_new_summary = summary is None
+                if is_new_summary:
+                    summary = PerformanceAlertSummary.objects.create(
+                        repository=signature.repository,
+                        framework=signature.framework,
+                        push_id=cur.push_id,
+                        sheriffed=not signature.monitor,
+                        prev_push_id=prev.push_id,
+                        manually_created=False,
+                        created=datetime.utcfromtimestamp(cur.push_timestamp),
+                    )
+
+                # Widen prev_push to the earliest seen across merged alerts,
+                # unless a sheriff manually created this summary with a specific prev_push.
+                if (
+                    not is_new_summary
+                    and not summary.manually_created
+                    and prev.push_id != summary.prev_push_id
+                ):
+                    existing_prev_timestamp = time.mktime(summary.prev_push.time.timetuple())
+                    if prev.push_timestamp < existing_prev_timestamp:
+                        summary.prev_push_id = prev.push_id
+                        summary.save(update_fields=["prev_push_id"])
 
                 # django/mysql doesn't understand "inf", so just use some
                 # arbitrarily high value for that case


### PR DESCRIPTION
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2035204

This PR prevents duplicate AlertSummary rows from being created for the same push.
When a new alert is merged into an existing AlertSummary, `prev_push_id` is widened to the earliest prev_push seen across the merged alerts, but never narrowed. This is because prev_push_id drives the PerfCompare link, so narrowing it could risk breaking existing references. Manually created summaries (with a sheriff-set prev_push) are left untouched.
Happy to hear any thoughts or concerns on this approach.