### PR TITLE
Increase performance data retention to 3 years max, and keep alerts indefinitely.

### DIFF
--- a/docs/data_cycling.md
+++ b/docs/data_cycling.md
@@ -28,27 +28,18 @@ All following strategies target the `performance_datum` table, which stores the 
 
 #### Generic
 
-Removes data points older than 1 year.
+Removes data points older than 3 years.
 
 #### Try data
 
-Removes data points originating from try pushes, that are older than 6 weeks.
+Removes data points originating from try pushes, that are older than 2 years.
 
 #### Not actively sheriffed
 
-Removes data points from repositories other than autoland, mozilla-central, mozilla-beta, fenix & reference-browser, which are older than 6 months.
-
-#### Stalled data
-
-Removes data points from series which haven't been ingesting new ones for the last 4 months.
-
-Data points which fall into the 'historical value' category from autoland and mozilla-central series aren't removed.
-Performance data is considered to have historical value if the average between the number of data points and the number of months in which these data points are spread is greater or equal to two data points per month.
+Removes data points from repositories other than autoland, mozilla-central, mozilla-beta, fenix & reference-browser, which are older than 6 months. Data from try is exempt, as it's handled by the try data strategy above.
 
 ### Garbage collection
 
-Removes performance signatures which no longer has any data points linked to them. This cascades to the linked alerts, as they don't make sense without a parent series.
-
 Removes alert summaries which no longer has any alerts linked to them.
 
-These kinds of data pertain to the `performance_signature`, `performance_alert` & `performance_alert_summary` table respectively.
+This kind of data pertains to the `performance_alert_summary` table.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -867,23 +867,6 @@ def test_perf_signature_4(test_perf_signature):
 
 
 @pytest.fixture
-def test_stalled_data_signature(test_perf_signature):
-    stalled_data_timestamp = datetime.datetime.now() - datetime.timedelta(days=120)
-    return perf_models.PerformanceSignature.objects.create(
-        repository=test_perf_signature.repository,
-        signature_hash=(20 * "t3"),
-        framework=test_perf_signature.framework,
-        platform=test_perf_signature.platform,
-        option_collection=test_perf_signature.option_collection,
-        suite="mysuite3",
-        test="mytest3",
-        has_subtests=test_perf_signature.has_subtests,
-        extra_options=test_perf_signature.extra_options,
-        last_updated=stalled_data_timestamp,
-    )
-
-
-@pytest.fixture
 def test_perf_data(test_perf_signature, eleven_jobs_stored):
     # for making things easier, ids for jobs
     # and push should be the same;

--- a/tests/model/cycle_data/test_perfherder_cycling.py
+++ b/tests/model/cycle_data/test_perfherder_cycling.py
@@ -14,7 +14,6 @@ from treeherder.model.data_cycling import (
 from treeherder.model.data_cycling.removal_strategies import (
     IrrelevantDataRemoval,
     MainRemovalStrategy,
-    StalledDataRemoval,
     TryDataRemoval,
 )
 from treeherder.model.models import Push
@@ -54,7 +53,7 @@ def test_cycle_performance_data(
     test_repository.name = repository_name
     test_repository.save()
 
-    expired_timestamp = datetime.now() - timedelta(days=400)
+    expired_timestamp = datetime.now() - timedelta(days=1100)
 
     test_perf_signature_2 = PerformanceSignature.objects.create(
         signature_hash="b" * 40,
@@ -105,47 +104,12 @@ def test_cycle_performance_data(
     call_command(*list(command))  # test repository isn't a main one
 
     assert list(PerformanceDatum.objects.values_list("id", flat=True)) == [1]
-    assert list(PerformanceSignature.objects.values_list("id", flat=True)) == [
-        test_perf_signature.id
-    ]
-
-
-def test_performance_signatures_are_deleted(test_perf_signature, taskcluster_notify_mock):
-    cycler = PerfherderCycler(chunk_size=100, sleep_time=0)
-    expired_timestamp = cycler.max_timestamp
-
-    perf_signature_to_delete = PerformanceSignature.objects.create(
-        signature_hash="b" * 40,
-        repository=test_perf_signature.repository,
-        framework=test_perf_signature.framework,
-        platform=test_perf_signature.platform,
-        option_collection=test_perf_signature.option_collection,
-        suite=test_perf_signature.suite,
-        test="test_perf_signature_to_delete",
-        last_updated=expired_timestamp,
-        has_subtests=False,
-    )
-
-    perf_signature_to_keep = PerformanceSignature.objects.create(
-        signature_hash="h" * 40,
-        repository=test_perf_signature.repository,
-        framework=test_perf_signature.framework,
-        platform=test_perf_signature.platform,
-        option_collection=test_perf_signature.option_collection,
-        suite=test_perf_signature.suite,
-        test="test_perf_signature_to_keep",
-        last_updated=datetime.now(),
-        has_subtests=False,
-    )
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert perf_signature_to_keep.id in list(
-        PerformanceSignature.objects.values_list("id", flat=True)
-    )
-    assert perf_signature_to_delete.id not in list(
-        PerformanceSignature.objects.values_list("id", flat=True)
-    )
+    # signatures are no longer garbage collected, so the one left without any
+    # data points sticks around
+    assert set(PerformanceSignature.objects.values_list("id", flat=True)) == {
+        test_perf_signature.id,
+        test_perf_signature_2.id,
+    }
 
 
 def test_try_data_removal(
@@ -165,7 +129,7 @@ def test_try_data_removal(
     for idx, push in enumerate(try_pushes[:-2]):
         push_timestamp = datetime.now()
         if idx < total_removals:
-            push_timestamp -= timedelta(weeks=10)
+            push_timestamp -= timedelta(days=740)
 
         PerformanceDatum.objects.create(
             repository=try_repository,
@@ -194,12 +158,38 @@ def test_try_data_removal(
     call_command("cycle_data", "from:perfherder")
     assert PerformanceDatum.objects.count() == total_initial_data - total_removals
     assert not PerformanceDatum.objects.filter(
-        push_timestamp__lt=datetime.now() - timedelta(weeks=6),
+        push_timestamp__lt=datetime.now() - timedelta(days=730),
         repository=try_repository,
     ).exists()
     assert (
         PerformanceDatum.objects.exclude(repository=try_repository).count() == 2
     )  # non-try data remained intact
+
+
+def test_try_data_younger_than_two_years_is_kept(
+    try_repository,
+    try_push_stored,
+    test_perf_signature,
+    taskcluster_notify_mock,
+):
+    # try isn't part of the actively sheriffed repositories, so make sure the
+    # irrelevant data removal strategy doesn't shorten try's retention period
+    test_perf_signature.repository = try_repository
+    test_perf_signature.save()
+
+    push = Push.objects.filter(repository=try_repository).first()
+    PerformanceDatum.objects.create(
+        repository=try_repository,
+        push=push,
+        job=None,
+        signature=test_perf_signature,
+        push_timestamp=datetime.now() - timedelta(days=200),
+        value=1.0,
+    )
+
+    call_command("cycle_data", "from:perfherder")
+
+    assert PerformanceDatum.objects.filter(repository=try_repository).count() == 1
 
 
 @pytest.mark.parametrize(
@@ -223,29 +213,29 @@ def test_irrelevant_repos_data_removal(
     test_repository.name = f"{test_repository.name}-test"
     test_repository.save()
 
-    six_months_ago_timestamp = datetime.now() - timedelta(days=(6 * 30))
+    expired_timestamp = datetime.now() - timedelta(days=740)
 
     push = Push.objects.first()
 
-    # performance datum for irrelevant repository which has an expired push_timestamp ( older than 6 months )
+    # performance datum for irrelevant repository which has an expired push_timestamp ( older than 2 years )
     # this one should be deleted, because it's expired
     PerformanceDatum.objects.create(
         repository=test_repository,
         push=push,
         job=None,
         signature=test_perf_signature,
-        push_timestamp=six_months_ago_timestamp,
+        push_timestamp=expired_timestamp,
         value=1.0,
     )
 
-    # performance datum for relevant repository which has a push_timestamp older than 6 months
+    # performance datum for relevant repository which has a push_timestamp older than 2 years
     # this one should still be kept in db
     PerformanceDatum.objects.create(
         repository=relevant_repository,
         push=push,
         job=None,
         signature=test_perf_signature,
-        push_timestamp=six_months_ago_timestamp,
+        push_timestamp=expired_timestamp,
         value=1.0,
     )
 
@@ -266,30 +256,9 @@ def test_irrelevant_repos_data_removal(
     assert PerformanceDatum.objects.count() == total_initial_data - 1
     assert PerformanceDatum.objects.filter(repository=relevant_repository).exists()
     assert not PerformanceDatum.objects.filter(
-        push_timestamp__lte=six_months_ago_timestamp,
+        push_timestamp__lte=expired_timestamp,
         repository=test_repository,
     ).exists()
-
-
-def test_signature_remover(
-    test_perf_signature,
-    test_perf_signature_2,
-    test_perf_data,
-    taskcluster_notify_mock,
-    mock_tc_prod_notify_credentials,
-):
-    cycler = PerfherderCycler(chunk_size=100, sleep_time=0)
-    expired_timestamp = cycler.max_timestamp
-    test_perf_signature_2.last_updated = expired_timestamp
-    test_perf_signature_2.save()
-
-    assert len(PerformanceSignature.objects.all()) == 2
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert taskcluster_notify_mock.email.call_count == 1
-    assert len(PerformanceSignature.objects.all()) == 1
-    assert PerformanceSignature.objects.first() == test_perf_signature
 
 
 @pytest.mark.parametrize("total_signatures", [3, 4, 8, 10])
@@ -540,246 +509,6 @@ def test_summary_with_alerts_isnt_deleted(
     assert PerformanceAlertSummary.objects.filter(id=empty_alert_summary.id).exists()
 
 
-def test_stalled_data_removal(
-    test_perf_signature, test_perf_signature_2, test_perf_data, test_perf_alert
-):
-    max_timestamp = datetime.now() - timedelta(days=120)
-    test_perf_signature.last_updated = max_timestamp - timedelta(days=2)
-    test_perf_signature.save()
-    test_perf_signature_2.last_updated = max_timestamp
-    test_perf_signature_2.save()
-
-    push = Push.objects.first()
-    seg2_data = PerformanceDatum.objects.create(
-        repository=test_perf_signature_2.repository,
-        push=push,
-        job=None,
-        signature=test_perf_signature_2,
-        push_timestamp=datetime.now(),
-        value=1.0,
-    )
-
-    test_perf_alert.created = max_timestamp
-    test_perf_alert.save()
-
-    assert test_perf_signature in PerformanceSignature.objects.filter(
-        last_updated__lt=max_timestamp
-    )
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert test_perf_signature_2 in PerformanceSignature.objects.all()
-    assert seg2_data in PerformanceDatum.objects.all()
-    assert test_perf_data not in PerformanceDatum.objects.all()
-    # TODO: I am not sure why these fail, after updating data everything else works but this
-    assert test_perf_alert not in PerformanceAlert.objects.all()
-    assert test_perf_signature not in PerformanceSignature.objects.all()
-
-
-@pytest.mark.parametrize(
-    "nr_months, repository",
-    [(8, "autoland"), (6, "autoland"), (5, "mozilla-central")],
-)
-def test_equal_distribution_for_historical_data(
-    test_repository,
-    test_stalled_data_signature,
-    test_perf_data,
-    nr_months,
-    repository,
-):
-    test_repository.name = repository
-    test_repository.save()
-
-    # Add 120 more days to timestamp because the concept of
-    # historical data is only for stalled data
-    timestamp = datetime.now() - timedelta(days=(nr_months * 30 + 120))
-    perf_signature = test_stalled_data_signature
-
-    push = Push.objects.first()
-    perf_data = []
-    data_points_count = 2 * nr_months
-
-    # Prepare test data: add two performance data points per month
-    for i in range(0, data_points_count):
-        if i % 2 == 0:
-            timestamp += timedelta(days=30)
-
-        data = PerformanceDatum.objects.create(
-            repository=perf_signature.repository,
-            push=push,
-            job=None,
-            signature=perf_signature,
-            push_timestamp=timestamp,
-            value=1.0,
-        )
-        perf_data.append(data)
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert PerformanceSignature.objects.filter(id=perf_signature.id).exists()
-    all_perf_datum = PerformanceDatum.objects.all()
-    for data_point in perf_data:
-        assert data_point in all_perf_datum
-
-
-@pytest.mark.parametrize(
-    "nr_months, repository",
-    [(8, "autoland"), (6, "autoland"), (5, "mozilla-central")],
-)
-def test_big_density_in_historical_data(
-    test_repository,
-    test_stalled_data_signature,
-    test_perf_data,
-    nr_months,
-    repository,
-):
-    test_repository.name = repository
-    test_repository.save()
-
-    # Add 120 more days to timestamp because the concept of
-    # historical data is only for stalled data
-    timestamp = datetime.now() - timedelta(days=(nr_months * 30 + 120))
-    perf_signature = test_stalled_data_signature
-
-    push = Push.objects.first()
-    perf_data = []
-    data_points_count = 2 * nr_months
-
-    # Prepare test data: add one data point per month
-    for i in range(0, nr_months):
-        timestamp += timedelta(days=30)
-
-        data = PerformanceDatum.objects.create(
-            repository=perf_signature.repository,
-            push=push,
-            job=None,
-            signature=perf_signature,
-            push_timestamp=timestamp,
-            value=1.0,
-        )
-        perf_data.append(data)
-
-    # Prepare test data: add the remaining data points to the last month which has data
-    for i in range(0, (data_points_count - nr_months)):
-        data = PerformanceDatum.objects.create(
-            repository=perf_signature.repository,
-            push=push,
-            job=None,
-            signature=perf_signature,
-            push_timestamp=timestamp,
-            value=1.0,
-        )
-        perf_data.append(data)
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert PerformanceSignature.objects.filter(id=perf_signature.id).exists()
-    all_perf_datum = PerformanceDatum.objects.all()
-    for data_point in perf_data:
-        assert data_point in all_perf_datum
-
-
-@pytest.mark.parametrize(
-    "nr_months, repository",
-    [(5, "autoland"), (8, "mozilla-central"), (11, "mozilla-central")],
-)
-def test_one_month_worth_of_data_points(
-    test_repository,
-    test_stalled_data_signature,
-    test_perf_data,
-    nr_months,
-    repository,
-):
-    assert nr_months >= 1  # as well need to subtract its start
-    covered_month_start = nr_months - 1
-
-    test_repository.name = repository
-    test_repository.save()
-
-    stalled_signature = test_stalled_data_signature
-    timestamp = datetime.now() - timedelta(days=covered_month_start * 30)
-
-    push = Push.objects.first()
-    perf_data = []
-
-    # Prepare test data: add data points to the parametrize month
-    for i in range(0, 15):
-        data = PerformanceDatum.objects.create(
-            repository=stalled_signature.repository,
-            push=push,
-            job=None,
-            signature=stalled_signature,
-            push_timestamp=timestamp,
-            value=1.0,
-        )
-        perf_data.append(data)
-
-    timestamp += timedelta(days=31)
-    data = PerformanceDatum.objects.create(
-        repository=stalled_signature.repository,
-        push=push,
-        job=None,
-        signature=stalled_signature,
-        push_timestamp=timestamp,
-        value=1.0,
-    )
-    perf_data.append(data)
-
-    call_command("cycle_data", "from:perfherder")
-
-    stalled_signature.refresh_from_db()
-    assert PerformanceSignature.objects.filter(id=stalled_signature.id).exists()
-    all_perf_datum = PerformanceDatum.objects.all()
-    for data_point in perf_data:
-        assert data_point in all_perf_datum
-
-
-@pytest.mark.parametrize(
-    "nr_months, repository",
-    [(8, "autoland"), (6, "autoland"), (5, "mozilla-central")],
-)
-def test_non_historical_stalled_data_is_removed(
-    test_repository,
-    test_stalled_data_signature,
-    test_perf_data,
-    nr_months,
-    repository,
-):
-    test_repository.name = repository
-    test_repository.save()
-
-    # Add 120 more days to timestamp because the concept of
-    # historical data is only for stalled data
-    timestamp = datetime.now() - timedelta(days=(nr_months * 30 + 120))
-    perf_signature = test_stalled_data_signature
-
-    push = Push.objects.first()
-    perf_data = []
-    data_points_count = nr_months
-
-    # Prepare test data: add one performance datum per month,
-    # not enough data to meet the condition for historical value
-    for i in range(0, data_points_count):
-        timestamp += timedelta(days=30)
-
-        data = PerformanceDatum.objects.create(
-            repository=perf_signature.repository,
-            push=push,
-            job=None,
-            signature=perf_signature,
-            push_timestamp=timestamp,
-            value=1.0,
-        )
-        perf_data.append(data)
-
-    call_command("cycle_data", "from:perfherder")
-
-    assert not PerformanceSignature.objects.filter(id=perf_signature.id).exists()
-    all_perf_datum = PerformanceDatum.objects.all()
-    for data_point in perf_data:
-        assert data_point not in all_perf_datum
-
-
 def test_try_data_removal_errors_out_on_missing_try_data(try_repository):
     try_removal_strategy = TryDataRemoval(10000)
 
@@ -801,9 +530,6 @@ def test_explicit_days_validation_on_all_envs(days):
 
     with pytest.raises(ValueError):
         _ = IrrelevantDataRemoval(10_000, days=days)
-
-    with pytest.raises(ValueError):
-        _ = StalledDataRemoval(10_000, days=days)
 
 
 def test_deleting_performance_data_cascades_to_perf_multicomit_data(test_perf_data):
@@ -846,14 +572,18 @@ def test_deleting_performance_data_cascades_to_perf_datum_replicate(test_perf_da
     assert PerformanceDatumReplicate.objects.count() == 0
 
 
-def test_alerts_older_than_a_year_are_removed_even_if_signature_is_active(test_perf_alert):
+def test_alerts_arent_removed_by_age_if_signature_is_active(test_perf_alert):
+    """
+    Alerts are no longer expired based on their own age: their data is now kept
+    for years, so an alert is only removed once its series is.
+    """
     # alert (fixture) comes pre linked to an active signature
     test_perf_alert.created = datetime.now() - timedelta(days=365)
     test_perf_alert.save()
 
     PerfherderCycler(10_000, 0).cycle()
 
-    assert not PerformanceAlert.objects.filter(id=test_perf_alert.id).exists()
+    assert PerformanceAlert.objects.filter(id=test_perf_alert.id).exists()
 
 
 def test_empty_backfill_reports_get_removed(empty_backfill_report):

--- a/tests/model/cycle_data/test_treeherder_cycling.py
+++ b/tests/model/cycle_data/test_treeherder_cycling.py
@@ -6,8 +6,16 @@ from django.db.models import Max
 
 from tests import test_utils
 from tests.autoclassify.utils import create_failure_lines, test_line
-from treeherder.model.models import FailureLine, Job, JobGroup, JobLog, JobType, Machine
-from treeherder.perf.models import PerformanceDatum
+from treeherder.model.models import (
+    FailureLine,
+    Job,
+    JobGroup,
+    JobLog,
+    JobType,
+    Machine,
+    MachinePlatform,
+)
+from treeherder.perf.models import PerformanceDatum, PerformanceSignature
 
 
 @pytest.mark.parametrize(
@@ -192,5 +200,36 @@ def test_cycle_job_with_performance_data(
     assert Job.objects.count() == 0
 
     # assert that the perf object is still there, but the job reference is None
-    p = PerformanceDatum.objects.filter(id=1).first()
-    assert p is None
+    perf_datum = PerformanceDatum.objects.get()
+    assert perf_datum.job is None
+
+
+def test_cycle_job_doesnt_prune_platforms_used_by_performance_data(
+    test_repository, failure_classifications, test_job, mock_log_parser, test_perf_signature
+):
+    """
+    Pruning ancillary data must not remove a `machine_platform` row that is
+    still referenced by a `performance_signature`. Perf data outlives jobs by
+    years, and the FK cascades, so pruning it would silently wipe out that
+    platform's entire perf history.
+    """
+    test_job.submit_time = datetime.now() - timedelta(weeks=1)
+    test_job.save()
+
+    PerformanceDatum.objects.create(
+        repository=test_repository,
+        push=test_job.push,
+        job=test_job,
+        signature=test_perf_signature,
+        push_timestamp=test_job.push.time,
+        value=1.0,
+    )
+    # no job is left referencing the signature's platform once the job is cycled
+    platform_id = test_perf_signature.platform_id
+
+    call_command("cycle_data", "from:treeherder", sleep_time=0, days=1, chunk_size=3)
+
+    assert Job.objects.count() == 0
+    assert MachinePlatform.objects.filter(id=platform_id).exists()
+    assert PerformanceSignature.objects.filter(id=test_perf_signature.id).exists()
+    assert PerformanceDatum.objects.count() == 1

--- a/treeherder/model/data_cycling/cyclers.py
+++ b/treeherder/model/data_cycling/cyclers.py
@@ -23,10 +23,8 @@ from treeherder.perf.models import (
     PerformanceAlertSummary,
     PerformanceSignature,
 )
-from treeherder.services import taskcluster
 
 from .max_runtime import MaxRuntime
-from .signature_remover import PublicSignatureRemover
 from .utils import has_valid_explicit_days
 
 logger = logging.getLogger(__name__)

--- a/treeherder/model/data_cycling/cyclers.py
+++ b/treeherder/model/data_cycling/cyclers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from django.db import OperationalError, connection
 from django.db.backends.utils import CursorWrapper
-from django.db.models import Count, Q
+from django.db.models import Count
 
 from treeherder.model.data_cycling.removal_strategies import RemovalStrategy
 from treeherder.model.models import (
@@ -20,7 +20,6 @@ from treeherder.model.models import (
 from treeherder.perf.exceptions import MaxRuntimeExceededError, NoDataCyclingAtAllError
 from treeherder.perf.models import (
     BackfillReport,
-    PerformanceAlert,
     PerformanceAlertSummary,
     PerformanceSignature,
 )
@@ -78,12 +77,22 @@ class TreeherderCycler(DataCycler):
     def _remove_leftovers(self):
         logger.warning("Pruning ancillary data: job types, groups and machines")
 
-        def prune(reference_model, id_name, model):
+        def prune(reference_model, id_name, model, also_used_by=None):
             logger.warning(f"Pruning {model.__name__}s")
             used_ids = (
                 reference_model.objects.only(id_name).values_list(id_name, flat=True).distinct()
             )
-            unused_ids = model.objects.exclude(id__in=used_ids).values_list("id", flat=True)
+            unused = model.objects.exclude(id__in=used_ids)
+            # some models outlive the jobs they were ingested with (performance
+            # data is kept for years, jobs for months), so any other model still
+            # referencing them must be honoured as well, or we'd cascade delete it
+            for other_model, other_id_name in also_used_by or []:
+                unused = unused.exclude(
+                    id__in=other_model.objects.only(other_id_name)
+                    .values_list(other_id_name, flat=True)
+                    .distinct()
+                )
+            unused_ids = unused.values_list("id", flat=True)
 
             logger.warning(f"Removing {len(unused_ids)} records from {model.__name__}")
 
@@ -98,7 +107,12 @@ class TreeherderCycler(DataCycler):
         prune(Job, "machine_id", Machine)
         prune(GroupStatus, "group_id", Group)
         prune(Job, "build_platform_id", BuildPlatform)
-        prune(Job, "machine_platform_id", MachinePlatform)
+        prune(
+            Job,
+            "machine_platform_id",
+            MachinePlatform,
+            also_used_by=[(PerformanceSignature, "platform_id")],
+        )
 
 
 class PerfherderCycler(DataCycler):
@@ -149,32 +163,8 @@ class PerfherderCycler(DataCycler):
             logger.warning(ex)
 
     def _remove_leftovers(self):
-        self.__remove_empty_signatures()
-
-        self.__remove_too_old_alerts()
         self.__remove_empty_alert_summaries()
-
         self.__remove_empty_backfill_reports()
-
-    def __remove_empty_signatures(self):
-        logger.warning("Removing performance signatures which don't have any data points...")
-        potentially_empty_signatures = PerformanceSignature.objects.filter(
-            last_updated__lte=self.max_timestamp
-        )
-        notify_client = taskcluster.notify_client_factory()
-
-        signatures_remover = PublicSignatureRemover(timer=self.timer, notify_client=notify_client)
-        signatures_remover.remove_in_chunks(potentially_empty_signatures)
-
-    def __remove_too_old_alerts(self):
-        logger.warning("Removing alerts older than a year...")
-        PerformanceAlert.objects.filter(
-            # WARNING! Don't change this without proper approval!           #
-            # Otherwise we risk deleting data that's actively investigated  #
-            # and cripple the perf sheriffing process!                      #
-            Q(created__lt=datetime.now() - timedelta(days=365)) | Q(created__isnull=True),
-            #################################################################
-        ).delete()
 
     def __remove_empty_alert_summaries(self):
         logger.warning("Removing alert summaries which no longer have any alerts...")

--- a/treeherder/model/data_cycling/removal_strategies.py
+++ b/treeherder/model/data_cycling/removal_strategies.py
@@ -52,7 +52,6 @@ class RemovalStrategy(ABC):
             MainRemovalStrategy(*args, **kwargs),
             TryDataRemoval(*args, **kwargs),
             IrrelevantDataRemoval(*args, **kwargs),
-            StalledDataRemoval(*args, **kwargs),
             # append here any new strategies
             # ...
         ]
@@ -61,13 +60,13 @@ class RemovalStrategy(ABC):
 class MainRemovalStrategy(RemovalStrategy):
     """
     Removes `performance_datum` rows
-    that are at least 1 year old.
+    that are at least 3 years old.
     """
 
     @property
     def cycle_interval(self) -> int:
         # WARNING!! Don't override this without proper approval!
-        return 365  # days                                     #
+        return 1095  # days (3 years)                          #
         ########################################################
 
     def __init__(self, chunk_size: int, days: int = None):
@@ -127,7 +126,7 @@ class TryDataRemoval(RemovalStrategy):
     """
     Removes `performance_datum` rows
     that originate from `try` repository and
-    that are more than 6 weeks old.
+    that are more than 2 years old.
     """
 
     SIGNATURE_BULK_SIZE = 10
@@ -135,7 +134,7 @@ class TryDataRemoval(RemovalStrategy):
     @property
     def cycle_interval(self) -> int:
         # WARNING!! Don't override this without proper approval!
-        return 42  # days                                      #
+        return 730  # days (2 years)                           #
         ########################################################
 
     def __init__(self, chunk_size: int, days: int = None):
@@ -260,7 +259,8 @@ class IrrelevantDataRemoval(RemovalStrategy):
     """
     Removes `performance_datum` rows that originate
     from repositories, other than the ones mentioned
-    in `RELEVANT_REPO_NAMES`, that are more than 6 months old.
+    in `RELEVANT_REPO_NAMES` & `EXCLUDED_REPO_NAMES`,
+    that are more than 6 months old.
     """
 
     RELEVANT_REPO_NAMES = [
@@ -271,10 +271,14 @@ class IrrelevantDataRemoval(RemovalStrategy):
         "reference-browser",
     ]
 
+    # `try` data has its own (longer) retention period, enforced by
+    # `TryDataRemoval`, so this strategy must leave it alone.
+    EXCLUDED_REPO_NAMES = ["try"]
+
     @property
     def cycle_interval(self) -> int:
         # WARNING!! Don't override this without proper approval!
-        return 180  # days                                     #
+        return 730  # days                                     #
         ########################################################
 
     def __init__(self, chunk_size: int, days: int = None):
@@ -292,9 +296,9 @@ class IrrelevantDataRemoval(RemovalStrategy):
     def irrelevant_repositories(self):
         if self.__irrelevant_repos is None:
             self.__irrelevant_repos = list(
-                Repository.objects.exclude(name__in=self.RELEVANT_REPO_NAMES).values_list(
-                    "id", flat=True
-                )
+                Repository.objects.exclude(
+                    name__in=self.RELEVANT_REPO_NAMES + self.EXCLUDED_REPO_NAMES
+                ).values_list("id", flat=True)
             )
         return self.__irrelevant_repos
 
@@ -355,133 +359,3 @@ class IrrelevantDataRemoval(RemovalStrategy):
                 self._max_timestamp,
             ],
         )
-
-
-class StalledDataRemoval(RemovalStrategy):
-    """
-    Removes `performance_datum` rows from `performance_signature`s
-    that haven't been updated in the last 4 months.
-
-    Exception: `performance_datum` rows that have a historical value (`autoland` /
-    `mozilla-central` series with an average of 2 data points per month)
-    are excluded and are kept for 1 year.
-    """
-
-    @property
-    def cycle_interval(self) -> int:
-        # WARNING!! Don't override this without proper approval!
-        return 120  # days                                     #
-        ########################################################
-
-    def __init__(self, chunk_size: int, days: int = None):
-        super().__init__(chunk_size, days=days)
-
-        self._target_signature = None
-        self._removable_signatures = None
-
-    @property
-    def target_signature(self) -> PerformanceSignature:
-        try:
-            if self._target_signature is None:
-                self._target_signature = self.removable_signatures.pop()
-        except IndexError:
-            msg = "No stalled signature found."
-            logger.warning(msg)  # no stalled data is not normal
-            raise LookupError(msg)
-        return self._target_signature
-
-    @property
-    def removable_signatures(self) -> list[PerformanceSignature]:
-        if self._removable_signatures is None:
-            self._removable_signatures = list(
-                PerformanceSignature.objects.filter(last_updated__lte=self._max_timestamp).order_by(
-                    "last_updated"
-                )
-            )
-            self._removable_signatures = [
-                sig
-                for sig in self._removable_signatures
-                if not sig.has_data_with_historical_value()
-            ]
-        return self._removable_signatures
-
-    def remove(self, using: CursorWrapper):
-        while True:
-            try:
-                self.__attempt_remove(using)
-
-                deleted_rows = using.rowcount
-                if deleted_rows > 0:
-                    break  # deletion was successful
-
-                self.__lookup_new_signature()  # to remove data from
-            except LookupError as ex:
-                logger.debug(
-                    f"Could not target any (new) stalled signature to delete data from. {ex}"
-                )
-                break
-
-    @property
-    def max_timestamp(self) -> datetime:
-        return self._max_timestamp
-
-    @property
-    def name(self) -> str:
-        return "stalled data removal strategy"
-
-    def __attempt_remove(self, using: CursorWrapper):
-        """
-        Raw SQL is used to avoid Django ORM cascade deletes on performance_datum_replicate.
-        Although the WHERE clause in del_replicate looks redundant, it is intentionally kept to guide
-        the PostgreSQL planner toward a more efficient execution plan.
-        """
-        using.execute(
-            """
-            WITH target_datum AS (
-                SELECT pd.id, pd.repository_id, pd.signature_id, pd.push_timestamp
-                FROM performance_datum pd
-                WHERE pd.repository_id = %s
-                AND pd.signature_id = %s
-                AND pd.push_timestamp <= %s
-                LIMIT %s
-            ),
-            del_replicate AS (
-                DELETE FROM performance_datum_replicate r1
-                WHERE r1.performance_datum_id IN (
-                    SELECT td.id
-                    FROM target_datum td
-                    WHERE td.repository_id = %s
-                    AND td.signature_id = %s
-                    AND td.push_timestamp <= %s
-                    AND EXISTS (
-                        SELECT 1
-                        FROM performance_datum_replicate r2
-                        WHERE r2.performance_datum_id = td.id
-                    )
-                )
-            ),
-            del_multi AS (
-                DELETE FROM perf_multicommitdatum pm
-                USING target_datum td
-                WHERE pm.perf_datum_id = td.id
-            )
-            DELETE FROM performance_datum pd
-            USING target_datum td
-            WHERE pd.id = td.id
-            """,
-            [
-                self.target_signature.repository_id,
-                self.target_signature.id,
-                self._max_timestamp,
-                self._chunk_size,
-                self.target_signature.repository_id,
-                self.target_signature.id,
-                self._max_timestamp,
-            ],
-        )
-
-    def __lookup_new_signature(self):
-        try:
-            self._target_signature = self._removable_signatures.pop()
-        except IndexError:
-            raise LookupError("Exhausted all stalled signatures.")

--- a/treeherder/perf/models.py
+++ b/treeherder/perf/models.py
@@ -118,42 +118,11 @@ class PerformanceSignature(models.Model):
                 return idx
         return None
 
-    @staticmethod
-    def _has_enough_data_points(perf_data):
-        if len(perf_data) >= 2:
-            start_date = perf_data[0].push_timestamp
-            end_date = perf_data[-1].push_timestamp
-
-            perf_data_count = len(perf_data)
-
-            num_months = (end_date.year - start_date.year) * 12 + (
-                end_date.month - start_date.month
-            )
-            if num_months >= 1:
-                min_distribution = 2
-                average_per_months = perf_data_count / num_months
-                if average_per_months >= min_distribution:
-                    return True
-        return False
-
     def has_performance_data(self):
         return PerformanceDatum.objects.filter(
             repository_id=self.repository_id,  # leverages (repository, signature) compound index
             signature_id=self.id,
         ).exists()
-
-    def has_data_with_historical_value(self):
-        repositories = ["autoland", "mozilla-central"]
-        if self.repository.name in repositories:
-            perf_data = list(
-                PerformanceDatum.objects.filter(
-                    repository_id=self.repository_id,  # leverages (repository, signature) compound index
-                    signature_id=self.id,
-                ).order_by("push_timestamp")
-            )
-            if self._has_enough_data_points(perf_data):
-                return True
-        return False
 
     class Meta:
         db_table = "performance_signature"


### PR DESCRIPTION
This patch increases performance data retention to 2 years for try, and 3 years for production branches. It also increases the alert storage to be indefinite - they can still be deleted if signatures are deleted but signature storage is also indefinite now. Note that there's a change to the Treeherder cycler to keep the machine platform as well.