### PR TITLE
Bug 1981626 Add new field denoting ordering of trial runs

### DIFF
--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -88,8 +88,8 @@
           "type": "boolean"
         },
         "orderedTrials": {
-          "description": "Whether the replicates list is ordered by trial run (1st value is 1st trial, 2nd value is 2nd trial, etc.)",
-            "title": "Trials ordered by run",
+          "description": "Whether the replicates list is ordered (default is by trial run).",
+            "title": "Trials ordered",
             "type": "boolean"
         },
         "shouldAlert": {
@@ -208,8 +208,8 @@
           "type": "boolean"
         },
         "orderedTrials": {
-          "description": "Whether the replicates list is ordered by trial run (1st value is 1st trial, 2nd value is 2nd trial, etc.)",
-          "title": "Trials ordered by run",
+          "description": "Whether the replicates list is ordered (default is by trial run).",
+          "title": "Trials ordered",
           "type": "boolean"
         },
         "shouldAlert": {

--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -202,6 +202,11 @@
           "title": "Lower is better",
           "type": "boolean"
         },
+        "trialsOrderedByRun": {
+          "description": "Whether the replicates list is ordered by trial run (1st value is 1st trial, 2nd value is 2nd trial, etc.)",
+          "title": "Trials ordered by run",
+          "type": "boolean"
+        },
         "shouldAlert": {
           "description": "Whether we should alert on this suite (overrides default behaviour)",
           "title": "Should alert",

--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -87,6 +87,11 @@
           "title": "Lower is better",
           "type": "boolean"
         },
+        "orderedTrials": {
+          "description": "Whether the replicates list is ordered by trial run (1st value is 1st trial, 2nd value is 2nd trial, etc.)",
+            "title": "Trials ordered by run",
+            "type": "boolean"
+        },
         "shouldAlert": {
           "description": "Whether we should alert",
           "title": "Should alert",

--- a/schemas/performance-artifact.json
+++ b/schemas/performance-artifact.json
@@ -202,7 +202,7 @@
           "title": "Lower is better",
           "type": "boolean"
         },
-        "trialsOrderedByRun": {
+        "orderedTrials": {
           "description": "Whether the replicates list is ordered by trial run (1st value is 1st trial, 2nd value is 2nd trial, etc.)",
           "title": "Trials ordered by run",
           "type": "boolean"


### PR DESCRIPTION
Bug: [Add new field to performance artifact schema to denote that trials are ordered by their run](https://bugzilla.mozilla.org/show_bug.cgi?id=1981626)

How are producers made aware of the new field? is that something I need to take care of as well?