### PR TITLE
Remove redundant per-report backfill log line

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -114,9 +114,6 @@ class Secretary:
 
         for report in mature_reports:
             should_freeze = False
-            logger.info(
-                f"Sherlock: Marking report [summary_id={report.summary.id}] for backfill..."
-            )
             for record in report.records.all():
                 if record.status == BackfillRecord.PRELIMINARY:
                     logger.info(


### PR DESCRIPTION
This log fires once per mature report, every run, unconditionally - even for reports where no record actually ends up READY_FOR_PROCESSING (that's decided later, per-record).
Two things make it low-value:
- `f"Sherlock: {mature_reports.count()} mature reports found."` already logs the volume.
- `f"Sherlock: Marking record [alert_id={record.alert.id}] as READY_FOR_PROCESSING..."` already logs the actually meaningful event - a record being marked READY_FOR_PROCESSING. That's the one worth keeping, since it reflects real state change.

The log I removed now just says "I'm about to look at this report," not that anything happened, so on GCP with many mature reports per run it's pure volume with no signal.

Example from the GCP log (before this fix):
<img width="519" height="184" alt="gcp_log" src="https://github.com/user-attachments/assets/9e9b38a7-09c3-4f36-971a-a27f1f791d05" />
