### PR TITLE
Bug 2062730 - Return machine_name with each performance summary datum

### DIFF
--- a/tests/webapp/api/test_performance_data_api.py
+++ b/tests/webapp/api/test_performance_data_api.py
@@ -583,6 +583,29 @@ def test_perf_summary_data_includes_submit_time(
     assert {row["submit_time"] for row in data} == expected
 
 
+@pytest.mark.parametrize("replicates", ["true", "false"])
+def test_perf_summary_data_includes_machine_name(
+    client, test_perf_signature, test_perf_data, replicates
+):
+    """
+    Check that "machine_name" is present on each datum.
+
+    We test both `replicates=true` `replicates=false` because the
+    two modes use different code to create the datum objects.
+    """
+    query_params = summary_query_params(test_perf_signature, test_perf_data, replicates=replicates)
+
+    response = client.get(reverse("performance-summary") + query_params)
+    assert response.status_code == 200
+
+    data = response.json()[0]["data"]
+    assert len(data) == len(test_perf_data)
+
+    expected_names = {datum.job.machine.name for datum in test_perf_data}
+    assert expected_names, "fixture jobs should have machines"
+    assert {row["machine_name"] for row in data} == expected_names
+
+
 def test_perf_summary_should_alert_is_false_edge_case(
     client, test_perf_signature, test_perf_signature_2, test_perf_data
 ):

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1027,6 +1027,7 @@ class PerformanceSummary(generics.ListAPIView):
                         push_revision,
                         replicate_value,
                         submit_time,
+                        machine_name,
                     ) in data.values_list(
                         "value",
                         "job_id",
@@ -1036,6 +1037,7 @@ class PerformanceSummary(generics.ListAPIView):
                         "push__revision",
                         "performancedatumreplicate__value",
                         "job__submit_time",
+                        "job__machine__name",
                     ).order_by("push_timestamp", "push_id", "job_id"):
                         if replicate_value is not None:
                             item["data"].append(
@@ -1047,6 +1049,7 @@ class PerformanceSummary(generics.ListAPIView):
                                     "push_timestamp": push_timestamp,
                                     "push__revision": push_revision,
                                     "job__submit_time": submit_time,
+                                    "job__machine__name": machine_name,
                                 }
                             )
                         elif value is not None:
@@ -1059,6 +1062,7 @@ class PerformanceSummary(generics.ListAPIView):
                                     "push_timestamp": push_timestamp,
                                     "push__revision": push_revision,
                                     "job__submit_time": submit_time,
+                                    "job__machine__name": machine_name,
                                 }
                             )
                 else:
@@ -1070,6 +1074,7 @@ class PerformanceSummary(generics.ListAPIView):
                         "push_timestamp",
                         "push__revision",
                         "job__submit_time",
+                        "job__machine__name",
                     ).order_by("push_timestamp", "push_id", "job_id")
 
                 item["option_name"] = option_collection_map[item["option_collection_id"]]

--- a/treeherder/webapp/api/performance_serializers.py
+++ b/treeherder/webapp/api/performance_serializers.py
@@ -489,10 +489,22 @@ class PerformanceDatumSerializer(serializers.ModelSerializer):
     submit_time = serializers.DateTimeField(
         required=False, allow_null=True, default=None, source="job__submit_time"
     )
+    machine_name = serializers.CharField(
+        required=False, allow_null=True, default=None, source="job__machine__name"
+    )
 
     class Meta:
         model = PerformanceDatum
-        fields = ["job_id", "id", "value", "push_timestamp", "push_id", "revision", "submit_time"]
+        fields = [
+            "job_id",
+            "id",
+            "value",
+            "push_timestamp",
+            "push_id",
+            "revision",
+            "submit_time",
+            "machine_name",
+        ]
 
 
 class PerformanceSummarySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Based on #9775.

https://bugzilla.mozilla.org/show_bug.cgi?id=2062730

This allows showing per-machine data in the graphs without requiring separate requests for each job's job details.

The potential costs of this change are:
- Increased database query time
- Increased response size

The query already looks at job submit times so it's already looking at the right table, so any query time regressions should be minor.
(Claude took a look in more detail and had more elaborate justifications but I didn't understand them so I'm not copying them here.)

The response size grows, but gzip mostly takes care of it because there aren't a lot of different machine names. I measured a 1050-row response as an example, and it grew by 16.8% raw and 3.2% gzipped ("0.6 bytes per row").

r? @gmierz 