### PR TITLE
Bug 2056962 - Clear the selected task when switching repos via the watched-repo links

### DIFF
--- a/tests/ui/helpers/location.test.js
+++ b/tests/ui/helpers/location.test.js
@@ -86,6 +86,15 @@ describe('updateRepoParams', () => {
     expect(result).not.toContain('author=');
   });
 
+  it('removes selection parameters when changing repo', () => {
+    window.location.search =
+      '?repo=autoland&selectedJob=456&selectedTaskRun=OeYt2-iLQSaQb2ashZ_VIQ.0';
+    const result = updateRepoParams('try');
+
+    expect(result).not.toContain('selectedJob=');
+    expect(result).not.toContain('selectedTaskRun=');
+  });
+
   it('preserves other parameters when changing repo', () => {
     window.location.search = '?repo=autoland&resultStatus=success&tier=1';
     const result = updateRepoParams('try');

--- a/tests/ui/job-view/stores/selectedJob_test.jsx
+++ b/tests/ui/job-view/stores/selectedJob_test.jsx
@@ -1,0 +1,71 @@
+import {
+  useSelectedJobStore,
+  syncSelectionFromUrl,
+} from '../../../../ui/shared/stores/selectedJobStore';
+
+jest.mock('../../../../ui/models/job', () => ({
+  __esModule: true,
+  default: {
+    getList: jest.fn(() => Promise.resolve({ data: [], failureStatus: null })),
+  },
+}));
+
+const testJob = {
+  id: 259537372,
+  task_id: 'OeYt2-iLQSaQb2ashZ_VIQ',
+  retry_id: 0,
+  job_type_name: 'source-test-mozlint-spell',
+};
+
+const notify = jest.fn();
+
+const setLocationSearch = (search) => {
+  window.history.replaceState(null, null, `/jobs${search}`);
+};
+
+beforeEach(() => {
+  notify.mockClear();
+  useSelectedJobStore.setState({ selectedJob: null });
+  setLocationSearch('?repo=autoland');
+});
+
+afterEach(() => {
+  setLocationSearch('');
+});
+
+describe('syncSelectionFromUrl', () => {
+  it('clears the selected job when the URL has no selection params', () => {
+    // A task was selected, then the user navigated to a URL without
+    // selectedTaskRun (e.g. switched repos via the watched-repo links).
+    useSelectedJobStore.setState({ selectedJob: testJob });
+    setLocationSearch('?repo=mozilla-central');
+
+    syncSelectionFromUrl({}, notify);
+
+    expect(useSelectedJobStore.getState().selectedJob).toBeNull();
+  });
+
+  it('clears the selected job when the task is not in the loaded jobs', () => {
+    // The URL still names a task, but the loaded pushes (e.g. after a repo
+    // switch) don't contain it.
+    useSelectedJobStore.setState({ selectedJob: testJob });
+    setLocationSearch(
+      '?repo=mozilla-central&selectedTaskRun=OeYt2-iLQSaQb2ashZ_VIQ.0',
+    );
+
+    syncSelectionFromUrl({}, notify);
+
+    expect(useSelectedJobStore.getState().selectedJob).toBeNull();
+  });
+
+  it('keeps the selected job when the task is in the loaded jobs', () => {
+    useSelectedJobStore.setState({ selectedJob: null });
+    setLocationSearch(
+      '?repo=autoland&selectedTaskRun=OeYt2-iLQSaQb2ashZ_VIQ.0',
+    );
+
+    syncSelectionFromUrl({ [testJob.id]: testJob }, notify);
+
+    expect(useSelectedJobStore.getState().selectedJob).toEqual(testJob);
+  });
+});

--- a/ui/helpers/location.js
+++ b/ui/helpers/location.js
@@ -54,6 +54,7 @@ export const updateRepoParams = function updateRepoParams(newRepoName) {
   const params = getAllUrlParams();
 
   params.delete('selectedJob');
+  params.delete('selectedTaskRun');
   params.delete('fromchange');
   params.delete('tochange');
   params.delete('revision');

--- a/ui/shared/stores/selectedJobStore.js
+++ b/ui/shared/stores/selectedJobStore.js
@@ -42,8 +42,16 @@ const doSelectJob = (job) => {
   return { selectedJob: job };
 };
 
+// ``countPinnedJobs`` may be a number of pinned jobs, or a pinned-jobs
+// object ({} when called from the URL-sync paths).  Only skip clearing
+// when jobs are actually pinned.
 const doClearSelectedJob = (countPinnedJobs) => {
-  if (!countPinnedJobs) {
+  const hasPinnedJobs =
+    typeof countPinnedJobs === 'number'
+      ? countPinnedJobs > 0
+      : Object.keys(countPinnedJobs || {}).length > 0;
+
+  if (!hasPinnedJobs) {
     const selected = findSelectedInstance();
     if (selected) selected.setSelected(false);
 


### PR DESCRIPTION
## Problem

If a user has a task selected and clicks a different tree in the second toolbar from the top, the new repository opens but the information about the previously selected task (task details, summary/failures tabs) persists. It should be dismissed, because that task is not part of the new repository.

## Root cause

Two defects compose:

1. **Stale URL param on repo switch.** The watched-repo links build their target URL with `updateRepoParams()`, which removed `revision`, `author`, `fromchange`, `tochange`, and the *legacy* `selectedJob` param — but not the current `selectedTaskRun` param. The old repo's selection traveled into the new repo's URL.

2. **The URL-sync clear path is a silent no-op.** When the new repo's jobs load, `setSelectedJobFromQueryString` correctly detects the task isn't present and calls `doClearSelectedJob({})`. In the pre-Zustand Redux store, `{}` was explicitly documented and handled as "no pinned jobs → clear the selection unconditionally". The Zustand migration (fc64ce235) simplified that to `if (!countPinnedJobs)` — and `{}` is truthy, so **every clear on the URL-sync path did nothing**. The store kept the old task, and since `App` derives the details-panel visibility from the store, the panel stayed open. (Before the migration the panel did close on repo switch, just noisily, with a spurious sticky "Task not found" notification and a pointless database search.)

## Fix

- `updateRepoParams()` now also deletes `selectedTaskRun`, so switching trees drops the selection immediately and skips the needless task-not-found lookup/notification.
- `doClearSelectedJob()` restores the number-or-object handling for `countPinnedJobs`. All existing callers pass numbers (`Object.keys(pinnedJobs).length` or `0`), so their behavior is unchanged; the object branch only revives the sync-path `{}` calls.

Both changes are needed: fixing only the store still produced a sticky error notification on every repo switch; fixing only the URL didn't clear the store because the sync clear was a no-op.

## Testing

New tests, written first and confirmed failing at the reported symptom before the fix:

- `tests/ui/helpers/location.test.js`: `updateRepoParams` removes both `selectedJob` and `selectedTaskRun`.
- `tests/ui/job-view/stores/selectedJob_test.jsx`: URL-sync clears the selected job when the URL has no selection params and when the named task is not in the loaded jobs, plus a control case verifying selection is kept when the task is present.

Full unit suite: 95 suites / 1062 tests pass. Lint clean.
