### PR TITLE
Eliminate lazy repository FK fetches in worker tasks and push health_summary

### DIFF
--- a/treeherder/etl/artifact.py
+++ b/treeherder/etl/artifact.py
@@ -83,7 +83,7 @@ def store_job_artifacts(artifact_data):
                 continue
 
             try:
-                job = Job.objects.get(guid=job_guid)
+                job = Job.objects.select_related("repository").get(guid=job_guid)
             except Job.DoesNotExist:
                 logger.error("load_job_artifacts: No job_id for guid %s", job_guid)
                 continue

--- a/treeherder/etl/classification_loader.py
+++ b/treeherder/etl/classification_loader.py
@@ -120,7 +120,7 @@ class ClassificationLoader:
             revision_field = "revision__startswith" if len(revision) < 40 else "revision"
             filter_kwargs = {"repository": repository, revision_field: revision}
 
-            push = Push.objects.get(**filter_kwargs)
+            push = Push.objects.select_related("repository").get(**filter_kwargs)
         except Push.DoesNotExist:
             logger.info("Job with unsupported revision: %s", revision)
             raise
@@ -154,7 +154,9 @@ class ClassificationLoader:
 
                 # Retrieving the relevant Job
                 try:
-                    job = Job.objects.get(taskcluster_metadata__task_id=task["task_id"])
+                    job = Job.objects.select_related("repository").get(
+                        taskcluster_metadata__task_id=task["task_id"]
+                    )
                 except Job.DoesNotExist:
                     logger.error(
                         "Job associated to the TC task %s does not exist and could not be autoclassified.",

--- a/treeherder/log_parser/intermittents.py
+++ b/treeherder/log_parser/intermittents.py
@@ -105,7 +105,7 @@ def _check_and_mark_infra(current_job, job_ids, push_ids):
 
 
 def check_and_mark_intermittent(job_id):
-    current_job = Job.objects.get(id=job_id)
+    current_job = Job.objects.select_related("repository", "job_type", "push").get(id=job_id)
     jtname = current_job.job_type.name.strip("-cf")
     ids = [current_job.push.id]
 

--- a/treeherder/log_parser/tasks.py
+++ b/treeherder/log_parser/tasks.py
@@ -28,7 +28,12 @@ def parse_logs(job_id, job_log_ids, priority):
     # Attach task_id/run_id/job_id as GCP log labels to every line emitted while
     # parsing this job's logs (including deeper failure-line processing).
     with log_context(**job_log_labels(job), component="log_parser"):
-        job_logs = JobLog.objects.filter(id__in=job_log_ids, job=job)
+        # select_related the job/repository chain: the parsers below access
+        # job_log.job.repository lazily, and by then the log downloads may have
+        # outlived the task's original DB connection.
+        job_logs = JobLog.objects.filter(id__in=job_log_ids, job=job).select_related(
+            "job__repository"
+        )
 
         if len(job_log_ids) != len(job_logs):
             logger.warning(

--- a/treeherder/perf/tasks.py
+++ b/treeherder/perf/tasks.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 @retryable_task(name="generate-alerts", max_retries=10)
 def generate_alerts(signature_id):
     newrelic.agent.add_custom_attribute("signature_id", str(signature_id))
-    signature = PerformanceSignature.objects.get(id=signature_id)
+    signature = PerformanceSignature.objects.select_related("repository", "framework").get(
+        id=signature_id
+    )
     generate_new_alerts_in_series(signature)
     # Test alert generation is temporarily disabled.
     # try:
@@ -45,7 +47,9 @@ def ingest_perfherder_data(job_id, job_log_ids):
     newrelic.agent.add_custom_attribute("job_id", str(job_id))
 
     job = Job.objects.get(id=job_id)
-    job_artifacts = JobLog.objects.filter(id__in=job_log_ids, job=job)
+    job_artifacts = JobLog.objects.filter(id__in=job_log_ids, job=job).select_related(
+        "job__repository"
+    )
 
     if len(job_log_ids) != len(job_artifacts):
         logger.warning(

--- a/treeherder/webapp/api/push.py
+++ b/treeherder/webapp/api/push.py
@@ -257,7 +257,7 @@ class PushViewSet(viewsets.ViewSet):
             try:
                 pushes = Push.objects.filter(
                     revision__in=revision.split(","), repository__name=project
-                )
+                ).select_related("repository")
             except Push.DoesNotExist:
                 return Response(f"No push with revision: {revision}", status=HTTP_404_NOT_FOUND)
         else:


### PR DESCRIPTION
## Problem

Production GCP logs show chained tracebacks of this shape:

```code
File "django/db/models/fields/related_descriptors.py", line 239, in __get__
    rel_obj = self.field.get_cached_value(instance)
  File "django/db/models/fields/mixins.py", line 37, in get_cached_value
    return instance._state.fields_cache[self.cache_name]
KeyError: 'repository'
```

That `KeyError` is Django's normal FK cache-miss path: it is caught inside `ForwardManyToOneDescriptor.__get__`, which then fetches the `Repository` row from the DB. When that one-off fetch fails, the failure is chained onto the `KeyError` ("During handling of the above exception...").

The trigger is model instances loaded **without** `select_related("repository")` in long-running celery tasks: the instance is fetched at task start, the task then spends a long time on other work (e.g. downloading logs over HTTP), and only afterwards touches `.repository` — by which point the connection backing the lazy fetch can have gone stale, so the task blows up mid-work instead of failing fast at task start under the normal retry path.

## Fix

Add `select_related` for the repository FK chain at the entry-point querysets:

- **log-parser task**: `JobLog` queryset gets `select_related("job__repository")` — the lazy accesses are on `job_log.job.repository` (two lazy hops) in `post_log_artifacts`, `failureline.py`, and the error-summary path
- **ingest-perfherder-data task**: same `job__repository` treatment; covers `etl/perf.py`'s `job.repository.performance_alerts_enabled` reads
- **generate-alerts task**: signature fetched with `select_related("repository", "framework")` — both are read repeatedly in `generate_new_alerts_in_series`, including inside the `select_for_update` transaction added in #9754
- **check_and_mark_intermittent**: job fetched with `select_related("repository", "job_type", "push")` — all three FKs are read
- **classification loader**: the `Job` lookup (`Job.__str__` reads `self.repository` when interpolated into a log line) and `get_push`'s `Push` lookup now select_related
- **push `health_summary` API**: the `revision=` branch gets the `select_related("repository")` its `author=` sibling branch already had

Besides removing the failure mode, this drops a query (or several) per task/request.

## Testing

Ran the backend suites for every touched module — `tests/log_parser/`, `tests/etl/test_classification_loader.py`, `test_load_artifacts.py`, `test_perf_data_load.py`, `tests/webapp/api/test_push_api.py`, `tests/perfalert/test_alerts.py`: 231 passed, 1 pre-existing xfail. No new tests: the change is query-shape only and all modified paths are covered by existing functional tests.