### PR TITLE
Fix details panel header flicker when selecting consecutive failed tasks

### DIFF
--- a/tests/ui/job-view/details/tabs/TabsPanel_test.jsx
+++ b/tests/ui/job-view/details/tabs/TabsPanel_test.jsx
@@ -1,0 +1,208 @@
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
+
+import TabsPanel from '../../../../../ui/job-view/details/tabs/TabsPanel';
+
+jest.mock(
+  '../../../../../ui/shared/tabs/failureSummary/FailureSummaryTab',
+  () => ({
+    __esModule: true,
+    default: () => null,
+  }),
+);
+jest.mock('../../../../../ui/job-view/details/tabs/summaryTab/SummaryTab', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../../../../ui/shared/JobArtifacts', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../../../../ui/job-view/details/tabs/PerformanceTab', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../../../../ui/job-view/details/tabs/AnnotationsTab', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../../../../ui/job-view/details/tabs/SimilarJobsTab', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('../../../../../ui/job-view/details/JobTestGroups', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const currentRepo = {
+  name: 'autoland',
+  tc_root_url: 'https://firefox-ci-tc.services.mozilla.com',
+};
+
+const selectedJob = {
+  id: 1,
+  task_id: 'TASK_A',
+  retry_id: 0,
+  resultStatus: 'testfailed',
+};
+
+const summaryArtifactUrl =
+  'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/TASK_A/runs/0/artifacts/public/summary.jsonl';
+
+const makeJobDetails = () => [
+  { url: summaryArtifactUrl, value: 'summary.jsonl', path: '' },
+  { url: 'https://example.com/log.txt', value: 'log.txt', path: '' },
+];
+
+const renderTabsPanel = (props = {}) =>
+  render(
+    <TabsPanel
+      selectedJob={selectedJob}
+      selectedJobFull={{ ...selectedJob }}
+      currentRepo={currentRepo}
+      jobDetails={makeJobDetails()}
+      classifications={[]}
+      classificationMap={{}}
+      bugs={[]}
+      togglePinBoardVisibility={() => {}}
+      jobLogUrls={[]}
+      logParseStatus="parsed"
+      perfJobDetail={[]}
+      testGroups={[]}
+      {...props}
+    />,
+  );
+
+describe('TabsPanel summary tab probing', () => {
+  let fetchMock;
+  let originalOffsetWidth;
+
+  beforeAll(() => {
+    // Give elements realistic widths so checkTabOverflow doesn't hide tabs in jsdom
+    originalOffsetWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'offsetWidth',
+    );
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      get() {
+        if (this.id === 'tab-header-buttons') return 100;
+        if (this.getAttribute('role') === 'tab') return 50;
+        return 1000;
+      },
+    });
+  });
+
+  afterAll(() => {
+    if (originalOffsetWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'offsetWidth',
+        originalOffsetWidth,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    window.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    delete window.fetch;
+  });
+
+  it('shows the Summary tab after probing the summary artifact', async () => {
+    renderTabsPanel();
+
+    expect(
+      await screen.findByRole('tab', { name: 'Summary' }),
+    ).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(summaryArtifactUrl, {
+      method: 'HEAD',
+    });
+  });
+
+  it('does not re-probe or remove the Summary tab when jobDetails is replaced with identical content', async () => {
+    const { rerender } = renderTabsPanel();
+
+    await screen.findByRole('tab', { name: 'Summary' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Simulate a poll cycle delivering a new array with the same artifacts
+    await act(async () => {
+      rerender(
+        <TabsPanel
+          selectedJob={selectedJob}
+          selectedJobFull={{ ...selectedJob }}
+          currentRepo={currentRepo}
+          jobDetails={makeJobDetails()}
+          classifications={[]}
+          classificationMap={{}}
+          bugs={[]}
+          togglePinBoardVisibility={() => {}}
+          jobLogUrls={[]}
+          logParseStatus="parsed"
+          perfJobDetail={[]}
+          testGroups={[]}
+        />,
+      );
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('tab', { name: 'Summary' })).toBeInTheDocument();
+  });
+
+  it('preserves a user-selected tab when jobDetails is replaced with identical content', async () => {
+    const { rerender } = renderTabsPanel();
+
+    await screen.findByRole('tab', { name: 'Summary' });
+
+    const annotationsTab = screen.getByRole('tab', { name: 'Annotations' });
+    fireEvent.click(annotationsTab);
+    expect(annotationsTab).toHaveAttribute('aria-selected', 'true');
+
+    await act(async () => {
+      rerender(
+        <TabsPanel
+          selectedJob={selectedJob}
+          selectedJobFull={{ ...selectedJob }}
+          currentRepo={currentRepo}
+          jobDetails={makeJobDetails()}
+          classifications={[]}
+          classificationMap={{}}
+          bugs={[]}
+          togglePinBoardVisibility={() => {}}
+          jobLogUrls={[]}
+          logParseStatus="parsed"
+          perfJobDetail={[]}
+          testGroups={[]}
+        />,
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('tab', { name: 'Annotations' }),
+      ).toHaveAttribute('aria-selected', 'true'),
+    );
+  });
+
+  it('selects the Failure Summary tab by default for a failed job', async () => {
+    renderTabsPanel();
+
+    await screen.findByRole('tab', { name: 'Summary' });
+    // Must hold in the same commit that first renders the Summary tab —
+    // a transient wrong selection here is the header flicker regression.
+    expect(
+      screen.getByRole('tab', { name: 'Failure Summary' }),
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/tests/ui/job-view/details/useJobDetails.test.js
+++ b/tests/ui/job-view/details/useJobDetails.test.js
@@ -1,6 +1,196 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { Queue } from 'taskcluster-client-web';
 
-import { fetchTaskData } from '../../../../ui/job-view/details/useJobDetails';
+import useJobDetails, {
+  fetchTaskData,
+} from '../../../../ui/job-view/details/useJobDetails';
+import JobModel from '../../../../ui/models/job';
+import JobLogUrlModel from '../../../../ui/models/jobLogUrl';
+import PerfSeriesModel from '../../../../ui/models/perfSeries';
+import JobClassificationModel from '../../../../ui/models/classification';
+import BugJobMapModel from '../../../../ui/models/bugJobMap';
+import { getData } from '../../../../ui/helpers/http';
+
+jest.mock('../../../../ui/models/job', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+jest.mock('../../../../ui/models/jobLogUrl', () => ({
+  __esModule: true,
+  default: { getList: jest.fn() },
+}));
+jest.mock('../../../../ui/models/perfSeries', () => ({
+  __esModule: true,
+  default: { getJobData: jest.fn() },
+}));
+jest.mock('../../../../ui/models/classification', () => ({
+  __esModule: true,
+  default: { getList: jest.fn() },
+}));
+jest.mock('../../../../ui/models/bugJobMap', () => ({
+  __esModule: true,
+  default: { getList: jest.fn() },
+}));
+jest.mock('../../../../ui/helpers/http', () => ({
+  getData: jest.fn(),
+}));
+
+const currentRepo = {
+  name: 'autoland',
+  tc_root_url: 'https://firefox-ci-tc.services.mozilla.com',
+};
+const frameworks = [];
+
+const makeJob = (overrides = {}) => ({
+  id: 1,
+  task_id: 'TASK_A',
+  retry_id: 0,
+  push_id: 10,
+  state: 'completed',
+  result: 'testfailed',
+  failure_classification_id: 1,
+  job_type_name: 'test-linux-mochitest-1',
+  job_type_symbol: 'M1',
+  job_group_name: 'Mochitests',
+  platform: 'linux1804-64',
+  platform_option: 'opt',
+  submit_timestamp: 1700000000,
+  start_timestamp: 1700000100,
+  end_timestamp: 1700000200,
+  ...overrides,
+});
+
+const mockResolvedFetches = ({ artifactName = 'public/summary.jsonl' } = {}) => {
+  JobModel.get.mockImplementation((repoName, id) =>
+    Promise.resolve(makeJob({ id, logs: [] })),
+  );
+  JobLogUrlModel.getList.mockResolvedValue([]);
+  PerfSeriesModel.getJobData.mockResolvedValue({
+    failureStatus: null,
+    data: { data: [] },
+  });
+  JobClassificationModel.getList.mockResolvedValue([]);
+  BugJobMapModel.getList.mockResolvedValue([]);
+  getData.mockResolvedValue({
+    failureStatus: null,
+    data: { artifacts: [{ name: artifactName, contentLength: 10 }] },
+  });
+};
+
+describe('useJobDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolvedFetches();
+  });
+
+  const renderJobDetails = (initialProps) =>
+    renderHook(
+      (props) =>
+        useJobDetails(
+          props.selectedJob,
+          props.currentRepo,
+          props.pushList,
+          props.frameworks,
+        ),
+      { initialProps },
+    );
+
+  it('clears stale artifact, perf, and test group data when a new job is selected', async () => {
+    const jobA = makeJob();
+    const pushList = [{ id: 10, revision: 'abc123' }];
+
+    const { result, rerender } = renderJobDetails({
+      selectedJob: jobA,
+      currentRepo,
+      pushList,
+      frameworks,
+    });
+
+    await waitFor(() => expect(result.current.jobDetails).toHaveLength(1));
+    expect(result.current.jobDetails[0].value).toBe('summary.jsonl');
+
+    // Job B's requests never resolve, so any lingering data belongs to job A
+    JobModel.get.mockImplementation(() => new Promise(() => {}));
+    getData.mockImplementation(() => new Promise(() => {}));
+
+    const jobB = makeJob({ id: 2, task_id: 'TASK_B' });
+    await act(async () => {
+      rerender({ selectedJob: jobB, currentRepo, pushList, frameworks });
+    });
+
+    expect(result.current.jobDetails).toEqual([]);
+    expect(result.current.perfJobDetail).toEqual([]);
+    expect(result.current.testGroups).toEqual([]);
+  });
+
+  it('does not refetch when the selected job and push list only change identity (poll)', async () => {
+    const jobA = makeJob();
+    const pushList = [{ id: 10, revision: 'abc123' }];
+
+    const { result, rerender } = renderJobDetails({
+      selectedJob: jobA,
+      currentRepo,
+      pushList,
+      frameworks,
+    });
+
+    await waitFor(() => expect(result.current.jobDetails).toHaveLength(1));
+    expect(JobModel.get).toHaveBeenCalledTimes(1);
+
+    // Simulate a poll cycle: same job data, new object identities
+    await act(async () => {
+      rerender({
+        selectedJob: { ...jobA },
+        currentRepo,
+        pushList: [...pushList],
+        frameworks,
+      });
+    });
+
+    // Wait past the debounce window to catch any scheduled reload
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+    });
+
+    expect(JobModel.get).toHaveBeenCalledTimes(1);
+    expect(getData).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when a meaningful job field changes (job completes)', async () => {
+    const jobA = makeJob({ state: 'running', result: 'unknown' });
+    const pushList = [{ id: 10, revision: 'abc123' }];
+
+    const { result, rerender } = renderJobDetails({
+      selectedJob: jobA,
+      currentRepo,
+      pushList,
+      frameworks,
+    });
+
+    await waitFor(() => expect(result.current.jobDetails).toHaveLength(1));
+    expect(JobModel.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rerender({
+        selectedJob: makeJob({ state: 'completed', result: 'testfailed' }),
+        currentRepo,
+        pushList,
+        frameworks,
+      });
+    });
+
+    // Same job id, so the reload is debounced
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+    });
+
+    expect(JobModel.get).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('fetchTaskData', () => {
   let consoleErrorSpy;

--- a/ui/job-view/details/tabs/TabsPanel.jsx
+++ b/ui/job-view/details/tabs/TabsPanel.jsx
@@ -93,15 +93,43 @@ const TabsPanel = ({
     addBug(bug, job);
   }, []);
 
-  const [tabIndex, setTabIndex] = useState(0);
   const [summaryUrl, setSummaryUrl] = useState(null);
   const [overflowTabs, setOverflowTabs] = useState([]);
   const [showOverflowDropdown, setShowOverflowDropdown] = useState(false);
   const [dropdownShow, setDropdownShow] = useState(false);
 
+  const showPerf = !!perfJobDetail.length;
+  const showSummary = !!summaryUrl;
+
+  const [tabIndex, setTabIndex] = useState(() =>
+    selectedJob
+      ? getDefaultTabIndex(selectedJob.resultStatus, { showPerf, showSummary })
+      : 0,
+  );
+
+  // Reset to the default tab whenever the job or the set of visible tabs
+  // changes. This is derived during render (not in an effect) so the selected
+  // tab is always consistent with the rendered tabs within a single commit —
+  // an effect would briefly commit a frame with the selection on the wrong
+  // tab, which flickers the tab header.
+  const defaultTabKey = selectedJob
+    ? `${selectedJob.id}-${showPerf}-${showSummary}`
+    : null;
+  const [prevDefaultTabKey, setPrevDefaultTabKey] = useState(defaultTabKey);
+  if (defaultTabKey !== prevDefaultTabKey) {
+    setPrevDefaultTabKey(defaultTabKey);
+    if (selectedJob) {
+      setTabIndex(
+        getDefaultTabIndex(selectedJob.resultStatus, {
+          showPerf,
+          showSummary,
+        }),
+      );
+    }
+  }
+
   const tabListRef = useRef(null);
   const resizeObserverRef = useRef(null);
-  const defaultTabKeyRef = useRef(null);
 
   const checkTabOverflow = useCallback(() => {
     if (!tabListRef.current) return;
@@ -226,21 +254,25 @@ const TabsPanel = ({
     setTabIndex(newTabIndex);
   }, []);
 
-  // Probe for the summary.jsonl artifact; only show the Summary tab when it exists
-  useEffect(() => {
-    const url =
-      jobDetails?.find((detail) => detail.value === 'summary.jsonl')?.url ||
-      jobDetails?.find((detail) => detail.value?.endsWith('_testsummary.jsonl'))
-        ?.url;
+  // Probe for the summary.jsonl artifact; only show the Summary tab when it
+  // exists. Keyed on the derived artifact URL (which embeds the task id), so
+  // a jobDetails array that merely changes identity — e.g. after a poll
+  // refetch — neither re-probes nor toggles the Summary tab off and back on.
+  const summaryArtifactUrl =
+    jobDetails?.find((detail) => detail.value === 'summary.jsonl')?.url ||
+    jobDetails?.find((detail) => detail.value?.endsWith('_testsummary.jsonl'))
+      ?.url ||
+    null;
 
+  useEffect(() => {
     setSummaryUrl(null);
-    if (!url) return undefined;
+    if (!summaryArtifactUrl) return undefined;
 
     let cancelled = false;
-    fetch(url, { method: 'HEAD' })
+    fetch(summaryArtifactUrl, { method: 'HEAD' })
       .then((resp) => {
         if (!cancelled && resp.ok) {
-          setSummaryUrl(url);
+          setSummaryUrl(summaryArtifactUrl);
         }
       })
       .catch(() => {
@@ -250,22 +282,7 @@ const TabsPanel = ({
     return () => {
       cancelled = true;
     };
-  }, [selectedJob?.task_id, selectedJob?.retry_id, jobDetails]);
-
-  // Effect for handling job changes and setting default tab index.
-  // Re-runs when the summary probe resolves so tab indexes stay in sync.
-  useEffect(() => {
-    if (!selectedJob) return;
-    const key = `${selectedJob.id}-${perfJobDetail.length}-${!!summaryUrl}`;
-    if (defaultTabKeyRef.current === key) return;
-    defaultTabKeyRef.current = key;
-    setTabIndex(
-      getDefaultTabIndex(selectedJob.resultStatus, {
-        showPerf: !!perfJobDetail.length,
-        showSummary: !!summaryUrl,
-      }),
-    );
-  }, [selectedJob, perfJobDetail, summaryUrl]);
+  }, [summaryArtifactUrl]);
 
   // Effect for setting up event listeners and resize observer
   useEffect(() => {
@@ -290,8 +307,6 @@ const TabsPanel = ({
   }, [checkTabOverflow]);
 
   const countPinnedJobs = Object.keys(pinnedJobs).length;
-  const showPerf = !!perfJobDetail.length;
-  const showSummary = !!summaryUrl;
   const enableTestGroupsTab = testGroups && testGroups.length > 0;
 
   return (

--- a/ui/job-view/details/useJobDetails.js
+++ b/ui/job-view/details/useJobDetails.js
@@ -150,10 +150,11 @@ function useJobDetails(selectedJob, currentRepo, pushList, frameworks) {
   const previousJobIdRef = useRef(null);
   const isFirstLoadRef = useRef(true);
 
-  const findPush = useCallback(
-    (pushId) => pushList.find((push) => pushId === push.id),
-    [pushList],
-  );
+  // Latest push list, readable from the load effect without retriggering it.
+  // The push list is replaced on every poll cycle; keying the effect on it
+  // would refetch job details (and flicker the details panel) once a minute.
+  const pushListRef = useRef(pushList);
+  pushListRef.current = pushList;
 
   // Update classifications when the classification changed event fires
   const updateClassifications = useCallback(async () => {
@@ -207,6 +208,14 @@ function useJobDetails(selectedJob, currentRepo, pushList, frameworks) {
     // For first load or initial job selection, load immediately
     const shouldDebounce = !isFirstLoad && !isNewJob;
 
+    // Drop the previous job's data immediately so the details panel (and the
+    // tabs derived from it) never renders one job's artifacts under another.
+    if (isNewJob && !isFirstLoad) {
+      setJobDetails([]);
+      setPerfJobDetail([]);
+      setTestGroups([]);
+    }
+
     const loadJobDetails = async (signal) => {
       if (!currentRepo) return;
 
@@ -214,7 +223,9 @@ function useJobDetails(selectedJob, currentRepo, pushList, frameworks) {
       setJobArtifactsLoading(true);
 
       try {
-        const push = findPush(selectedJob.push_id);
+        const push = pushListRef.current.find(
+          (p) => p.id === selectedJob.push_id,
+        );
 
         const artifactsParams = {
           jobId: selectedJob.id,
@@ -427,7 +438,10 @@ function useJobDetails(selectedJob, currentRepo, pushList, frameworks) {
       }
       abortController.abort();
     };
-    // We track specific fields that should trigger a reload
+    // We track the specific fields that should trigger a reload. The
+    // selectedJob object itself is deliberately NOT a dependency: polling
+    // replaces job objects with identical data, and refetching on identity
+    // changes makes the details panel flicker.
   }, [
     selectedJob?.id,
     selectedJob?.state,
@@ -435,8 +449,6 @@ function useJobDetails(selectedJob, currentRepo, pushList, frameworks) {
     selectedJob?.failure_classification_id,
     currentRepo,
     frameworks,
-    findPush,
-    selectedJob,
   ]);
 
   return {


### PR DESCRIPTION
## Problem

Selecting consecutive tasks (most visible with the **N** key on failed tasks), and even the 60-second job poll with a selection held, made the details panel tabs header flicker: the Summary tab was removed and re-added, the selected tab briefly flipped to the wrong tab (Annotations / Artifacts flashes), and the `summary.jsonl` artifact was re-probed — including a stale `HEAD` request for the *previously* selected task.

Measured with a MutationObserver on the tab header (staging, failed tasks): each selection produced 4 transient wrong-selection flips plus a stale probe, and the identical cycle replayed on every poll with no user action.

## Root causes and fixes

**`useJobDetails.js`**
- Stale data: the previous job's `jobDetails` / `perfJobDetail` / `testGroups` stayed in state while the new job's fetches resolved, so the tabs (and the artifact probe) were derived from the old job's data. They are now cleared as soon as the selection changes.
- Spurious refetches: the load effect depended on the `selectedJob` object and a `findPush` callback rebuilt from `pushList` — both replaced on every poll. It now depends only on the meaningful job fields (`id`, `state`, `result`, `failure_classification_id`), reading the push list through a ref, so polls no longer refetch an unchanged selection.

**`TabsPanel.jsx`**
- The summary probe was keyed on the `jobDetails` array identity and always nulled `summaryUrl` before re-probing, toggling the Summary tab off and back on. It is now keyed on the derived artifact URL string (which embeds the task id), so identical content neither re-probes nor toggles the tab.
- The default tab index was set in an effect, one commit after the tab set changed, committing a frame with the selection on the wrong tab. It is now derived during render, so the selected tab and the tab set always change in the same commit. Side benefit: a user-selected tab now survives poll cycles instead of being reset.

## Verification

- 7 new unit tests (written first, watched fail on the old code): stale-data clearing, no refetch on identity-only poll changes, refetch still happens when a job completes, no re-probe/toggle on identical `jobDetails`, user tab preserved across polls, correct tab selected in the same commit the Summary tab appears.
- Full suite: 97 suites / 1068 tests passing; lint clean.
- Re-ran the MutationObserver measurement against the fixed build on staging data: consecutive selections and N-key navigation show zero selection flips and exactly one probe per selection (correct task only); a held selection through poll cycles produces zero header mutations.