### PR TITLE
Update timestamp when marking backfill FAILED after 72-hour timeout

### DIFF
--- a/treeherder/perf/auto_perf_sheriffing/secretary.py
+++ b/treeherder/perf/auto_perf_sheriffing/secretary.py
@@ -173,6 +173,7 @@ class Secretary:
                     new_note = "Backfill exceeded 72-hour limit, marking as FAILED."
                     log_entry = {
                         "notes": f"{last_log.get('notes', '')} {new_note}".strip(),
+                        "timestamp": datetime.now(UTC).isoformat(),
                     }
                     record.update_backfill_log(last_log["iteration"], log_entry)
                     record.save()


### PR DESCRIPTION
Add missing timestamp field to the backfill log entry when a record is marked FAILED for exceeding the 72-hour limit, so the log reflects when the failure was recorded instead of leaving the stale original timestamp.