### PR TITLE
Bug 2064659 - Graphs View: Add a checkbox to HighlightOptionsDropdown to indicate that multiple options can be selected at once

### DIFF
--- a/ui/perfherder/graphs/HighlightOptionsDropdown.jsx
+++ b/ui/perfherder/graphs/HighlightOptionsDropdown.jsx
@@ -34,7 +34,7 @@ const HighlightOptionsDropdown = ({
   ];
 
   return (
-    <Dropdown className="me-0 text-nowrap" title="Highlight Options Dropdown">
+    <Dropdown className="me-0 text-nowrap">
       <Dropdown.Toggle
         variant="secondary"
         aria-label="Highlight Options Dropdown"
@@ -47,15 +47,23 @@ const HighlightOptionsDropdown = ({
           <Dropdown.Item
             key={key}
             as="button"
+            className="d-flex align-items-center"
             onClick={() => updateStateParams({ [key]: !isChecked })}
+            role="menuitemcheckbox"
+            aria-checked={isChecked}
           >
-            {isChecked && (
-              <FontAwesomeIcon
-                icon={faCheck}
-                className="me-2"
-                title="Selected"
-              />
-            )}
+            <span
+              className="border border-secondary rounded me-2 d-flex align-items-center justify-content-center"
+              style={{ width: '18px', height: '18px' }}
+              aria-hidden="true"
+            >
+              {isChecked && (
+                <FontAwesomeIcon
+                  icon={faCheck}
+                  style={{ fontSize: '12px' }}
+                />
+              )}
+            </span>
             {label}
           </Dropdown.Item>
         ))}


### PR DESCRIPTION
[Bug 2064659 - Graphs View: Add a checkbox to HighlightOptionsDropdown to indicate that multiple options can be selected at once](https://bugzilla.mozilla.org/show_bug.cgi?id=2064659)

Before:
<img width="271" height="224" alt="image" src="https://github.com/user-attachments/assets/f46fff4e-62e0-41b4-8d4d-0752e479095b" />

After:
<img width="271" height="224" alt="image" src="https://github.com/user-attachments/assets/83e391c5-4c85-433d-9861-154ebb9bfa28" />
