### PR TITLE
Bug 2062817 - use https://lando.moz.tools as new treestatus host also…

### DIFF
--- a/tests/ui/integration/job-view/jobs_view.spec.js
+++ b/tests/ui/integration/job-view/jobs_view.spec.js
@@ -104,7 +104,7 @@ async function mockJobsViewApi(page) {
 
   // External services.
   await page.route(
-    'https://treestatus.prod.lando.prod.cloudops.mozgcp.net/**',
+    'https://lando.moz.tools/**',
     (route) =>
       route.fulfill(
         json({ result: { status: 'open', reason: '', tree: 'autoland' } }),


### PR DESCRIPTION
… in integration test