### PR TITLE
Silently recover a lapsed backend session on page load

### DIFF
--- a/tests/ui/shared/AuthService.test.js
+++ b/tests/ui/shared/AuthService.test.js
@@ -362,6 +362,58 @@ describe('AuthService', () => {
     });
   });
 
+  describe('recoverSession', () => {
+    it('saves credentials and returns the user when renew succeeds', async () => {
+      const authResult = { accessToken: 'new-token' };
+      const recoveredUser = { email: 'test@mozilla.com', is_staff: false };
+      mockRenew.mockResolvedValue(authResult);
+      authService.saveCredentialsFromAuthResult = jest
+        .fn()
+        .mockResolvedValue(recoveredUser);
+
+      const result = await authService.recoverSession();
+
+      expect(mockRenew).toHaveBeenCalled();
+      expect(authService.saveCredentialsFromAuthResult).toHaveBeenCalledWith(
+        authResult,
+      );
+      expect(result).toEqual(recoveredUser);
+    });
+
+    it('returns null when renew fails (e.g. refresh token revoked)', async () => {
+      mockRenew.mockRejectedValue(new Error('login_required'));
+
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await authService.recoverSession();
+
+      expect(result).toBeNull();
+      console.warn.mockRestore();
+    });
+
+    it('returns null when renew returns a falsy result', async () => {
+      mockRenew.mockResolvedValue(null);
+
+      const result = await authService.recoverSession();
+
+      expect(result).toBeNull();
+    });
+
+    it('does not clear the stored session on failure (caller decides)', async () => {
+      localStorage.setItem('userSession', '{"accessToken":"tok"}');
+      mockRenew.mockRejectedValue(new Error('network'));
+
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await authService.recoverSession();
+
+      expect(localStorage.getItem('userSession')).toBe(
+        '{"accessToken":"tok"}',
+      );
+      console.warn.mockRestore();
+    });
+  });
+
   describe('logout', () => {
     it('clears renewalLock from localStorage', () => {
       localStorage.setItem('renewalLock', Date.now().toString());

--- a/tests/ui/shared/Login.test.jsx
+++ b/tests/ui/shared/Login.test.jsx
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the Login component's page-load session handling.
+ *
+ * The Django session is capped (AUTH_MAX_SESSION_AGE_SECONDS) so it lapses
+ * whenever the renewal heartbeat stops for longer than the cap (laptop
+ * asleep, browser closed overnight). The Auth0 refresh token usually remains
+ * valid much longer, so on page load the component must attempt a silent
+ * session recovery before treating the user as logged out.
+ */
+import { render, waitFor } from '@testing-library/react';
+
+import Login from '../../../ui/shared/auth/Login';
+import UserModel from '../../../ui/models/user';
+
+const mockRecoverSession = jest.fn();
+const mockLogout = jest.fn();
+const mockResetRenewalTimer = jest.fn();
+
+jest.mock('../../../ui/shared/auth/AuthService', () =>
+  jest.fn().mockImplementation(() => ({
+    recoverSession: (...args) => mockRecoverSession(...args),
+    logout: (...args) => mockLogout(...args),
+    resetRenewalTimer: (...args) => mockResetRenewalTimer(...args),
+  })),
+);
+
+jest.mock('../../../ui/helpers/auth', () => ({
+  loggedOutUser: {
+    isStaff: false,
+    username: '',
+    email: '',
+    isLoggedIn: false,
+  },
+}));
+
+jest.mock('../../../ui/models/user');
+
+const storedSession = JSON.stringify({
+  accessToken: 'tok',
+  idToken: 'id',
+  fullName: 'Test User',
+  renewAfter: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+});
+
+describe('Login page-load session handling', () => {
+  let setUser;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    setUser = jest.fn();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+  });
+
+  const renderLogin = () =>
+    render(<Login setUser={setUser} user={{ isLoggedIn: false }} />);
+
+  it('sets the user as logged in when the backend session is still valid', async () => {
+    localStorage.setItem('userSession', storedSession);
+    UserModel.get.mockResolvedValue({ email: 'test@mozilla.com' });
+
+    renderLogin();
+
+    await waitFor(() =>
+      expect(setUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'test@mozilla.com',
+          isLoggedIn: true,
+        }),
+      ),
+    );
+    expect(mockRecoverSession).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it('recovers the session silently when the backend session lapsed but a userSession remains', async () => {
+    localStorage.setItem('userSession', storedSession);
+    // Backend session lapsed: anonymous response with no email
+    UserModel.get.mockResolvedValue({ email: '' });
+    mockRecoverSession.mockResolvedValue({
+      email: 'test@mozilla.com',
+      isStaff: false,
+    });
+
+    renderLogin();
+
+    await waitFor(() => expect(mockRecoverSession).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(setUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'test@mozilla.com',
+          isLoggedIn: true,
+        }),
+      ),
+    );
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it('logs out when silent recovery fails', async () => {
+    localStorage.setItem('userSession', storedSession);
+    UserModel.get.mockResolvedValue({ email: '' });
+    mockRecoverSession.mockResolvedValue(null);
+
+    renderLogin();
+
+    await waitFor(() => expect(mockRecoverSession).toHaveBeenCalled());
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled());
+    expect(setUser).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoggedIn: false }),
+    );
+  });
+
+  it('logs out without attempting recovery when no userSession exists', async () => {
+    UserModel.get.mockResolvedValue({ email: '' });
+
+    renderLogin();
+
+    await waitFor(() => expect(mockLogout).toHaveBeenCalled());
+    expect(mockRecoverSession).not.toHaveBeenCalled();
+  });
+});

--- a/ui/shared/auth/AuthService.js
+++ b/ui/shared/auth/AuthService.js
@@ -208,6 +208,34 @@ export default class AuthService {
     }
   }
 
+  /**
+   * Re-establish a lapsed backend session using the Auth0 refresh token.
+   *
+   * The Django session is capped (AUTH_MAX_SESSION_AGE_SECONDS) so it lapses
+   * whenever the renewal heartbeat stops for longer than the cap (laptop
+   * asleep, browser closed overnight). The refresh token usually remains
+   * valid much longer, so a silent renewal can log the user back in without
+   * any interaction. Returns the logged-in user on success, or null if the
+   * refresh token can no longer be used (e.g. revoked SSO access), in which
+   * case the caller should log the user out.
+   */
+  async recoverSession() {
+    try {
+      authLog('Attempting silent session recovery...');
+      const authResult = await renew();
+      if (!authResult) {
+        authWarn('Silent session recovery returned no credentials');
+        return null;
+      }
+      const user = await this.saveCredentialsFromAuthResult(authResult);
+      authInfo('Session recovered silently for:', user.email);
+      return user;
+    } catch (err) {
+      authWarn('Silent session recovery failed:', err.error || err.message);
+      return null;
+    }
+  }
+
   logout() {
     authInfo('Logging out user');
     localStorage.removeItem('userSession');
@@ -229,5 +257,7 @@ export default class AuthService {
 
     localStorage.setItem('userSession', JSON.stringify(userSession));
     localStorage.setItem('user', JSON.stringify(user));
+
+    return user;
   }
 }

--- a/ui/shared/auth/Login.jsx
+++ b/ui/shared/auth/Login.jsx
@@ -67,12 +67,24 @@ const Login = ({ setUser, user = { isLoggedIn: false }, notify }) => {
     window.addEventListener('storage', handleStorageEvent);
 
     // Ask the back-end if a user is logged in on page load
-    UserModel.get().then((currentUser) => {
+    UserModel.get().then(async (currentUser) => {
       if (currentUser.email && localStorage.getItem('userSession')) {
         setLoggedIn(currentUser);
-      } else {
-        setLoggedOut();
+        return;
       }
+      // The backend session is capped (AUTH_MAX_SESSION_AGE_SECONDS) and may
+      // have lapsed while the Auth0 refresh token is still valid (laptop
+      // asleep, browser closed overnight). Attempt a silent renewal before
+      // treating the user as logged out; it fails fast for a user whose SSO
+      // access was actually revoked.
+      if (localStorage.getItem('userSession')) {
+        const recoveredUser = await authServiceRef.current.recoverSession();
+        if (recoveredUser) {
+          setLoggedIn(recoveredUser);
+          return;
+        }
+      }
+      setLoggedOut();
     });
 
     return () => {


### PR DESCRIPTION
## Problem

Since #9688 capped the Django session at `AUTH_MAX_SESSION_AGE_SECONDS` (45 min), any user whose renewal heartbeat stops for longer than the cap (laptop asleep, browser closed overnight, backgrounded tab) loses their backend session. On the next page load the frontend saw the anonymous backend response and called `logout()`, which wipes the auth0-spa-js refresh-token cache — forcing an interactive re-login even though the refresh token was still perfectly valid.

Users who previously stayed logged in across ~a day of inactivity were now logged out after any 45-minute gap.

## Fix

- Add `AuthService.recoverSession()`: uses the Auth0 refresh token (`getTokenSilently`) to obtain fresh tokens and re-establish the backend session via the existing `/auth/login/` flow. Returns the logged-in user, or `null` if the refresh token can no longer be used.
- `Login.jsx` page-load flow now attempts this silent recovery before treating the user as logged out. Only if recovery fails does it clear credentials.
- `saveCredentialsFromAuthResult` now returns the fetched user to support this.

## Security property of #9688 is preserved

A user whose SSO access was revoked cannot recover: their refresh token fails at Auth0, `recoverSession()` returns `null`, and they are logged out within the cap window exactly as before. Ordinary users stay logged in for the life of their refresh token (~a day or more of inactivity).

## Tests

- New `tests/ui/shared/Login.test.jsx` covering the four page-load paths (valid session, lapsed-but-recoverable, recovery fails, no stored session).
- New `recoverSession` cases in `tests/ui/shared/AuthService.test.js` (success, renew failure, falsy result, no side effects on failure).
- Full suite: 99 suites / 1084 tests passing.