### PR TITLE
Bug-2038705: Remove usage of fetch_api and fetch_api_full_url

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -243,7 +243,7 @@ docker compose exec backend ./manage.py ingest push -p autoland --last-n-pushes 
 docker compose exec backend ./manage.py ingest task -p autoland -r 1ee42a54a431acdd6cbe43b49de0237fe67eddd9 --task-id <TASK-ID> --enable-eager-celery
 ```
 
-#### Ingest a single Github push or the last 10
+#### Ingest a single Github push or all git pushes
 
 ```bash
 docker compose exec backend ./manage.py ingest git-push -p servo-try -c 92fc94588f3b6987082923c0003012fd696b1a2d
@@ -258,6 +258,19 @@ docker compose exec -e GITHUB_TOKEN=<foo> backend ./manage.py ingest git-pushes 
     If you make too many calls to the Github API you will start getting 403 messages because of the rate limit.
     To avoid this visit [your settings](https://github.com/settings/tokens) and set up `GITHUB_TOKEN`. You don't need
     to grant scopes for it.
+
+To time GitHub API usage after the PyGithub migration (use a token, and `--dry-run` so `git-pushes` does not write):
+
+```bash
+# Changelog walks each configured repo for `--days` (default 1), at most 100 commits/releases each
+time docker compose exec backend ./manage.py update_changelog --days 1
+
+# One compare (plus parent lookups when the merge base is not the branch tip)
+time docker compose exec -e GITHUB_TOKEN=<foo> backend ./manage.py ingest git-push -p servo-try -c 92fc94588f3b6987082923c0003012fd696b1a2d
+
+# Paginates the default branch; log line "Fetched N commits from Github" is the size of the walk
+time docker compose exec -e GITHUB_TOKEN=<foo> backend ./manage.py ingest git-pushes -p android-components --dry-run
+```
 
 #### Ingesting Github PRs
 

--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -1,57 +1,10 @@
-import binascii
-import json
-import os
-import re
 from datetime import UTC, datetime, timedelta
 from unittest import mock
-
-import responses
 
 from treeherder.changelog.collector import collect
 
 
-def random_id():
-    return binascii.hexlify(os.urandom(16)).decode("utf8")
-
-
-COMMITS = re.compile(r"https://api.github.com/repos/.*/.*/commits\?.*")
-COMMIT_INFO = re.compile(r"https://api.github.com/repos/.*/.*/commits/.*")
-
-
-def prepare_responses():
-    now = datetime.now(tz=UTC).isoformat(timespec="seconds")
-
-    def _commit():
-        files = [{"filename": "file1"}, {"filename": "file2"}]
-        return {
-            "files": files,
-            "name": "ok",
-            "sha": random_id(),
-            "html_url": "url",
-            "tag_name": "some tag",
-            "commit": {
-                "message": "yeah",
-                "author": {"name": "tarek", "date": now},
-                "files": files,
-            },
-        }
-
-    def commits(request):
-        return 200, {}, json.dumps([_commit()])
-
-    responses.add_callback(
-        responses.GET, COMMITS, callback=commits, content_type="application/json"
-    )
-
-
-@responses.activate
-@mock.patch("treeherder.utils.github.pygithub_get_repo")
-def test_collect(mock_pygithub_get_repo):
-    now = datetime.now(tz=UTC)
-    yesterday = now - timedelta(days=1)
-    yesterday_str = yesterday.isoformat(timespec="seconds")
-
-    # Mock the GitRelease object structure expected by collector.py
+def _mock_github_repo(now):
     mock_author = mock.Mock()
     mock_author.login = "mock_tarek_release"
     mock_release = mock.Mock()
@@ -62,25 +15,37 @@ def test_collect(mock_pygithub_get_repo):
     mock_release.html_url = "mock_release_url"
     mock_release.author = mock_author
 
-    # Mock the file and commit object
     mock_file1 = mock.Mock()
     mock_file1.filename = "file1"
     mock_file2 = mock.Mock()
     mock_file2.filename = "file2"
 
     mock_commit = mock.Mock()
+    mock_commit.sha = "mock_commit_sha"
+    mock_commit.html_url = "url"
     mock_commit.files = [mock_file1, mock_file2]
-    mock_commit.commit.committer.date = now.isoformat()
+    mock_commit.commit.message = "yeah"
+    mock_commit.commit.author.name = "tarek"
+    mock_commit.commit.author.date = now
+    mock_commit.commit.committer.date = now
     mock_parent = mock.Mock()
     mock_parent.sha = "mock_parent_sha"
     mock_commit.parents = [mock_parent]
 
     mock_repo = mock.Mock()
     mock_repo.get_releases.return_value = [mock_release]
+    mock_repo.get_commits.return_value = [mock_commit]
     mock_repo.get_commit.return_value = mock_commit
-    mock_pygithub_get_repo.return_value = mock_repo
+    return mock_repo
 
-    prepare_responses()
+
+@mock.patch("treeherder.utils.github.pygithub_get_repo")
+def test_collect(mock_pygithub_get_repo):
+    now = datetime.now(tz=UTC)
+    yesterday = now - timedelta(days=1)
+    yesterday_str = yesterday.isoformat(timespec="seconds")
+
+    mock_pygithub_get_repo.return_value = _mock_github_repo(now)
     res = list(collect(yesterday_str))
 
     # Assertions to ensure both release and commit data are collected
@@ -95,7 +60,7 @@ def test_collect(mock_pygithub_get_repo):
     assert release_entry["url"] == "mock_release_url"
     assert release_entry["date"] == now.isoformat(timespec="seconds")
 
-    # Verify a commit entry created from responses mock
+    # Verify a commit entry created from the mock PyGithub object
     commit_entry = next((item for item in res if item["type"] == "commit"), None)
     assert commit_entry is not None
     assert commit_entry["author"] == "tarek"

--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -65,3 +65,30 @@ def test_collect(mock_pygithub_get_repo):
     assert commit_entry is not None
     assert commit_entry["author"] == "tarek"
     assert commit_entry["message"] == "yeah"
+    assert commit_entry["date"] == now.isoformat(timespec="seconds")
+
+
+@mock.patch("treeherder.utils.github.pygithub_get_repo")
+def test_get_changes_filter_by_path_loads_files_via_get_commit(mock_pygithub_get_repo):
+    """filter_by_path still uses get_commit() for file lists, not the list-commits payload."""
+    now = datetime.now(tz=UTC)
+    mock_repo = _mock_github_repo(now)
+    mock_pygithub_get_repo.return_value = mock_repo
+
+    from treeherder.changelog.collector import GitHub
+
+    changes = list(
+        GitHub().get_changes(
+            user="o",
+            repository="r",
+            filters=[["filter_by_path", "file1"]],
+            number=10,
+            since=now.isoformat(timespec="seconds"),
+        )
+    )
+
+    mock_repo.get_commit.assert_called_once_with("mock_commit_sha")
+    commit_changes = [c for c in changes if c["type"] == "commit"]
+    assert len(commit_changes) == 1
+    assert commit_changes[0]["files"] == ["file1", "file2"]
+    assert commit_changes[0]["date"] == now.isoformat(timespec="seconds")

--- a/tests/changelog/test_tasks.py
+++ b/tests/changelog/test_tasks.py
@@ -2,47 +2,18 @@ from datetime import UTC, datetime
 from unittest import mock
 
 import pytest
-import responses
 
-from tests.changelog.test_collector import prepare_responses
+from tests.changelog.test_collector import _mock_github_repo
 from treeherder.changelog.models import Changelog
 from treeherder.changelog.tasks import update_changelog
 
 
 @pytest.mark.django_db()
-@responses.activate
 @mock.patch("treeherder.utils.github.pygithub_get_repo")
 def test_update_changelog(mock_pygithub_get_repo):
-    # Mock the GitRelease object structure expected by collector.py
     now = datetime.now(tz=UTC)
-    mock_author = mock.Mock()
-    mock_author.login = "mock_tarek_release"
-    mock_release = mock.Mock()
-    mock_release.name = "mock_release_name"
-    mock_release.tag_name = "mock_release_tag"
-    mock_release.published_at = now
-    mock_release.id = "mock_release_id_123"
-    mock_release.html_url = "mock_release_url"
-    mock_release.author = mock_author
+    mock_pygithub_get_repo.return_value = _mock_github_repo(now)
 
-    mock_file1 = mock.Mock()
-    mock_file1.filename = "file1"
-    mock_file2 = mock.Mock()
-    mock_file2.filename = "file2"
-
-    mock_commit = mock.Mock()
-    mock_commit.files = [mock_file1, mock_file2]
-    mock_commit.commit.committer.date = now.isoformat()
-    mock_parent = mock.Mock()
-    mock_parent.sha = "mock_parent_sha"
-    mock_commit.parents = [mock_parent]
-
-    mock_repo = mock.Mock()
-    mock_repo.get_releases.return_value = [mock_release]
-    mock_repo.get_commit.return_value = mock_commit
-    mock_pygithub_get_repo.return_value = mock_repo
-
-    prepare_responses()
     num_entries = Changelog.objects.count()
 
     update_changelog()

--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from treeherder.etl.management.commands import ingest
 
 REPO_META = {
@@ -9,56 +11,63 @@ REPO_META = {
 }
 
 
-def test_query_data_consumes_compare_dict(monkeypatch):
-    """query_data must read the GitHub compare REST response as a dict.
+def _commit_obj(
+    sha, message=None, author_name=None, author_email=None, committer_date=None, parents=None
+):
+    return SimpleNamespace(
+        sha=sha,
+        commit=SimpleNamespace(
+            message=message,
+            author=SimpleNamespace(name=author_name, email=author_email),
+            committer=SimpleNamespace(date=committer_date),
+        ),
+        parents=[SimpleNamespace(sha=parent_sha) for parent_sha in (parents or [])],
+    )
 
-    Regression guard for Bug 2009865, which switched ``compare_shas`` to return
-    a list of PyGithub commit objects (for the Pulse push loader) but left
-    query_data doing dict access (``.get("merge_base_commit")`` / ``["commits"]``),
-    breaking the ``ingest push`` command for GitHub repos.
+
+def test_query_data_consumes_comparison_object(monkeypatch):
+    """query_data must read a PyGithub Comparison object, not a REST dict.
+
+    Regression guard for Bug 2009865 / Bug 2038705: ``compare_shas`` returns
+    PyGithub objects, and query_data must use attribute access so ``ingest push``
+    still works for GitHub repos.
     """
     compare_by_range = {
         # base branch vs head: the head isn't on the base branch, so the API
         # reports a merge base whose parent is the real fork point.
-        "main...HEAD": {
-            "merge_base_commit": {
-                "sha": "BASE",
-                "commit": {"committer": {"date": "2026-01-01T00:00:00Z"}},
-                "parents": [
-                    {
-                        "sha": "PARENT",
-                        "url": "https://api.github.com/repos/o/r/commits/PARENT",
-                    }
-                ],
-            },
-            "commits": [],
-        },
+        ("main", "HEAD"): SimpleNamespace(
+            merge_base_commit=_commit_obj(
+                sha="BASE",
+                committer_date="2026-01-01T00:00:00Z",
+                parents=["PARENT"],
+            ),
+            commits=[],
+        ),
         # re-compare with the corrected base yields the push's commits
-        "PARENT...HEAD": {
-            "merge_base_commit": {"sha": "PARENT", "parents": []},
-            "commits": [
-                {
-                    "sha": "C1",
-                    "commit": {
-                        "message": "Fix the thing",
-                        "author": {"name": "Dev", "email": "dev@example.com"},
-                        "committer": {"date": "2026-02-02T00:00:00Z"},
-                    },
-                }
+        ("PARENT", "HEAD"): SimpleNamespace(
+            merge_base_commit=_commit_obj(sha="PARENT", parents=[]),
+            commits=[
+                _commit_obj(
+                    sha="C1",
+                    message="Fix the thing",
+                    author_name="Dev",
+                    author_email="dev@example.com",
+                    committer_date="2026-02-02T00:00:00Z",
+                )
             ],
-        },
+        ),
     }
 
-    def fake_fetch_api(path, params=None):
-        return compare_by_range[path.split("/compare/")[1]]
+    def fake_compare_shas(owner, repo, base, head, get_comparison_object=False):
+        return compare_by_range[(base, head)]
 
-    def fake_fetch_api_full_url(url, params=None):
+    def fake_get_commit(owner, repo, sha):
         # The merge-base parent, with a committer date different from the merge
         # base so query_data takes the simple (non-recursive) branch.
-        return {"sha": "PARENT", "commit": {"committer": {"date": "2026-02-02T00:00:00Z"}}}
+        return {"sha": sha, "commit": {"committer": {"date": "2026-02-02T00:00:00Z"}}}
 
-    monkeypatch.setattr(ingest, "fetch_api", fake_fetch_api)
-    monkeypatch.setattr(ingest, "fetch_api_full_url", fake_fetch_api_full_url)
+    monkeypatch.setattr(ingest, "compare_shas", fake_compare_shas)
+    monkeypatch.setattr(ingest, "get_commit", fake_get_commit)
 
     event_base_sha, commits = ingest.query_data(REPO_META, "HEAD")
 

--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -132,3 +132,44 @@ def test_ingest_pr_handles_missing_trailing_slash(monkeypatch):
     assert payload["details"]["event.pullNumber"] == "1692"
     assert payload["details"]["event.base.repo.url"] == "https://github.com/mozilla/treeherder.git"
     assert payload["details"]["event.head.repo.url"] == "https://github.com/mozilla/treeherder.git"
+
+
+def test_ingest_git_pushes_uses_list_commit_metadata(monkeypatch):
+    """git-pushes should not issue a get_commit() per SHA; list-commits has parents/dates."""
+    monkeypatch.setattr(ingest, "GITHUB_TOKEN", "token")
+    monkeypatch.setattr(ingest, "repo_meta", lambda project: REPO_META)
+
+    commits = [
+        {
+            "sha": "C2",
+            "parents": [{"sha": "C1"}],
+            "commit": {"committer": {"date": "2026-02-02T00:00:00Z"}},
+        },
+        {
+            "sha": "C1",
+            "parents": [{"sha": "ROOT"}],
+            "commit": {"committer": {"date": "2026-01-01T00:00:00Z"}},
+        },
+    ]
+    get_commit_calls = []
+    monkeypatch.setattr(ingest.github, "get_all_commits", lambda owner, repo: commits)
+    monkeypatch.setattr(
+        ingest.github, "get_commit", lambda owner, repo, sha: get_commit_calls.append(sha)
+    )
+
+    ingested = []
+    monkeypatch.setattr(ingest, "ingest_push", lambda project, revision: ingested.append(revision))
+
+    class FakeClient:
+        def __init__(self, server_url=None):
+            pass
+
+        def get_pushes(self, project, count=None):
+            return [{"revision": revision} for revision in ingested]
+
+    monkeypatch.setattr(ingest, "TreeherderClient", FakeClient)
+
+    ingest.ingest_git_pushes("proj", dry_run=False)
+
+    assert get_commit_calls == []
+    assert ingested == ["C2", "C1"]

--- a/tests/etl/test_push_loader.py
+++ b/tests/etl/test_push_loader.py
@@ -1,6 +1,8 @@
 import copy
 import json
 import os
+from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 import responses
@@ -8,6 +10,7 @@ import responses
 from treeherder.etl.push_loader import (
     GithubPullRequestTransformer,
     GithubPushTransformer,
+    GithubTransformer,
     HgPushFetchError,
     HgPushTransformer,
     PulsePushError,
@@ -163,6 +166,35 @@ def mock_hg_push_commits(activate_responses):
 def test_get_transformer_class(exchange, transformer_class):
     rsl = PushLoader()
     assert rsl.get_transformer_class(exchange) == transformer_class
+
+
+def test_process_push_reads_pygithub_commit_attributes():
+    """Pulse GitHub transformers consume PyGithub commit objects, not REST dicts."""
+    transformer = GithubTransformer.__new__(GithubTransformer)
+    committed_at = datetime(2020, 2, 12, 15, 29, 12, tzinfo=UTC)
+    commit = SimpleNamespace(
+        sha="abc123",
+        commit=SimpleNamespace(
+            message="Fix the thing",
+            author=SimpleNamespace(name="Dev", email="dev@example.com"),
+            committer=SimpleNamespace(date=committed_at),
+        ),
+    )
+
+    push = transformer.process_push([commit])
+
+    assert push == {
+        "revision": "abc123",
+        "push_timestamp": committed_at.timestamp(),
+        "author": "dev@example.com",
+        "revisions": [
+            {
+                "comment": "Fix the thing",
+                "author": "Dev <dev@example.com>",
+                "revision": "abc123",
+            }
+        ],
+    }
 
 
 def test_unsupported_exchange():

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -64,7 +64,9 @@ class MockCommit:
                     "name": self.commit.author.name,
                     "date": self.commit.author.date,
                 },
+                "committer": {"date": self.commit.committer.date},
             },
+            "parents": [{"sha": p.sha} for p in self.parents],
         }
 
 
@@ -195,7 +197,7 @@ def test_get_releases_no_params(mock_github):
     expected_result = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
 
     # Assertions
-    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}", lazy=True)
     assert len(result) == 3
     assert result == expected_result
 
@@ -410,7 +412,7 @@ def test_get_commit_standard(github_commit_mock):
     result = get_commit(owner, repo, sha)
 
     # Assertions
-    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}", lazy=True)
     assert result == {
         "sha": sha,
         "files": [{"filename": "file1.py"}, {"filename": "file2.py"}],
@@ -509,7 +511,7 @@ def test_get_all_commits_no_params(mock_github):
 
     result = get_all_commits(owner, repo)
 
-    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}", lazy=True)
     assert result == [c.to_expected_dict() for c in commit_list]
 
 

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 # Import the function to be tested
-from treeherder.utils.github import get_releases
+from treeherder.utils.github import get_all_commits, get_releases
 
 
 # Mock GitCommit and it's related classes
@@ -23,17 +23,49 @@ class MockCommitter:
         self.date = date
 
 
+class MockCommitAuthor:
+    def __init__(self, name, date, email="dev@example.com"):
+        self.name = name
+        self.date = date
+        self.email = email
+
+
 class MockInnerCommit:
-    def __init__(self, committer_date):
+    def __init__(self, committer_date, message="", author_name="author"):
         self.committer = MockCommitter(committer_date)
+        self.message = message
+        self.author = MockCommitAuthor(author_name, committer_date)
 
 
 class MockCommit:
-    def __init__(self, sha, committer_date, parents=None, files=None):
+    def __init__(
+        self,
+        sha,
+        committer_date,
+        parents=None,
+        files=None,
+        message="",
+        html_url=None,
+        author_name="author",
+    ):
         self.sha = sha
-        self.commit = MockInnerCommit(committer_date)
+        self.commit = MockInnerCommit(committer_date, message, author_name)
         self.parents = [MockCommitParent(p_sha) for p_sha in parents] if parents else []
         self.files = [MockCommitFile(f_name) for f_name in files] if files else []
+        self.html_url = html_url or f"https://github.com/mock-owner/mock-repo/commit/{sha}"
+
+    def to_expected_dict(self):
+        return {
+            "sha": self.sha,
+            "html_url": self.html_url,
+            "commit": {
+                "message": self.commit.message,
+                "author": {
+                    "name": self.commit.author.name,
+                    "date": self.commit.author.date,
+                },
+            },
+        }
 
 
 @pytest.fixture
@@ -114,9 +146,10 @@ class MockGitRelease:
 
 # Mock Repository class to simulate PyGithub's Repository objects
 class MockRepository:
-    def __init__(self, releases=None, commits=None):
+    def __init__(self, releases=None, commits=None, commit_list=None):
         self._releases = releases or []
         self._commits = commits or {}
+        self._commit_list = commit_list or []
 
     def get_releases(self):
         # PyGithub's get_releases returns an iterable (PaginatedList),
@@ -126,6 +159,12 @@ class MockRepository:
 
     def get_commit(self, sha):
         return self._commits[sha]
+
+    def get_commits(self, since=None, **kwargs):
+        commits = self._commit_list
+        if since:
+            commits = [c for c in commits if c.commit.author.date >= since]
+        return commits
 
 
 @patch("treeherder.utils.github.github")
@@ -373,6 +412,7 @@ def test_get_commit_standard(github_commit_mock):
     # Assertions
     mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
     assert result == {
+        "sha": sha,
         "files": [{"filename": "file1.py"}, {"filename": "file2.py"}],
         "commit": {"committer": {"date": date_str}},
         "parents": [{"sha": "parentsha1"}, {"sha": "parentsha2"}],
@@ -400,6 +440,7 @@ def test_get_commit_initial_commit(github_commit_mock):
     result = get_commit(owner, repo, sha)
 
     assert result == {
+        "sha": sha,
         "files": [{"filename": "README.md"}],
         "commit": {"committer": {"date": date_str}},
         "parents": [],
@@ -427,7 +468,121 @@ def test_get_commit_no_files(github_commit_mock):
     result = get_commit(owner, repo, sha)
 
     assert result == {
+        "sha": sha,
         "files": [],
         "commit": {"committer": {"date": date_str}},
         "parents": [{"sha": "parentsha"}],
     }
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_no_params(mock_github):
+    """
+    Test get_all_commits returns all commits when no filtering parameters are provided.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    commit_1 = MockCommit(
+        "sha1",
+        datetime(2023, 1, 1, 10, 0, tzinfo=UTC),
+        message="Commit 1",
+        author_name="dev1",
+    )
+    commit_2 = MockCommit(
+        "sha2",
+        datetime(2023, 1, 5, 12, 0, tzinfo=UTC),
+        message="Commit 2",
+        author_name="dev2",
+    )
+    commit_3 = MockCommit(
+        "sha3",
+        datetime(2023, 1, 10, 14, 0, tzinfo=UTC),
+        message="Commit 3",
+        author_name="dev3",
+    )
+    # Simulate PyGithub's reverse chronological order
+    commit_list = [commit_3, commit_2, commit_1]
+
+    mock_repo_instance = MockRepository(commit_list=commit_list)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    result = get_all_commits(owner, repo)
+
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    assert result == [c.to_expected_dict() for c in commit_list]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_number_param(mock_github):
+    """
+    Test get_all_commits returns at most N newest commits when filtered by 'number'.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    commit_1 = MockCommit("sha1", datetime(2023, 1, 1, 10, 0, tzinfo=UTC), message="Commit 1")
+    commit_2 = MockCommit("sha2", datetime(2023, 1, 5, 12, 0, tzinfo=UTC), message="Commit 2")
+    commit_3 = MockCommit("sha3", datetime(2023, 1, 10, 14, 0, tzinfo=UTC), message="Commit 3")
+    commit_list = [commit_3, commit_2, commit_1]
+
+    mock_repo_instance = MockRepository(commit_list=commit_list)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    result = get_all_commits(owner, repo, {"number": 2})
+    assert result == [c.to_expected_dict() for c in commit_list[:2]]
+
+    result_large = get_all_commits(owner, repo, {"number": 10})
+    assert result_large == [c.to_expected_dict() for c in commit_list]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_since_param(mock_github):
+    """
+    Test get_all_commits returns commits at or after the 'since' parameter.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    commit_1 = MockCommit("sha1", datetime(2023, 1, 1, 10, 0, tzinfo=UTC), message="Commit 1")
+    commit_2 = MockCommit("sha2", datetime(2023, 1, 5, 12, 0, tzinfo=UTC), message="Commit 2")
+    commit_3 = MockCommit("sha3", datetime(2023, 1, 10, 14, 0, tzinfo=UTC), message="Commit 3")
+    commit_list = [commit_3, commit_2, commit_1]
+
+    mock_repo_instance = MockRepository(commit_list=commit_list)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    result = get_all_commits(owner, repo, {"since": "2023-01-05T12:00:00+00:00"})
+    assert result == [commit_3.to_expected_dict(), commit_2.to_expected_dict()]
+
+    result_later = get_all_commits(owner, repo, {"since": "2023-01-15T00:00:00+00:00"})
+    assert result_later == []
+
+    result_earlier = get_all_commits(owner, repo, {"since": "2022-12-31T00:00:00+00:00"})
+    assert result_earlier == [c.to_expected_dict() for c in commit_list]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_number_and_since_params(mock_github):
+    """
+    Test get_all_commits applies 'since' then limits by 'number'.
+    """
+    owner = "test-owner"
+    repo = "test-repo"
+
+    commit_1 = MockCommit("sha1", datetime(2023, 1, 1, 10, 0, tzinfo=UTC), message="Commit 1")
+    commit_2 = MockCommit("sha2", datetime(2023, 1, 5, 12, 0, tzinfo=UTC), message="Commit 2")
+    commit_3 = MockCommit("sha3", datetime(2023, 1, 10, 14, 0, tzinfo=UTC), message="Commit 3")
+    commit_4 = MockCommit("sha4", datetime(2023, 1, 15, 16, 0, tzinfo=UTC), message="Commit 4")
+    commit_5 = MockCommit("sha5", datetime(2023, 1, 20, 18, 0, tzinfo=UTC), message="Commit 5")
+    commit_list = [commit_5, commit_4, commit_3, commit_2, commit_1]
+
+    mock_repo_instance = MockRepository(commit_list=commit_list)
+    mock_github.get_repo.return_value = mock_repo_instance
+
+    result = get_all_commits(owner, repo, {"since": "2023-01-05T12:00:00+00:00", "number": 3})
+    assert result == [
+        commit_5.to_expected_dict(),
+        commit_4.to_expected_dict(),
+        commit_3.to_expected_dict(),
+    ]

--- a/treeherder/changelog/collector.py
+++ b/treeherder/changelog/collector.py
@@ -51,8 +51,13 @@ class GitHub:
 
             message = commit["commit"]["message"]
             message = message.split("\n")[0]
+            commit_date = commit["commit"]["author"]["date"]
+            if isinstance(commit_date, datetime):
+                if commit_date.tzinfo is None:
+                    commit_date = commit_date.replace(tzinfo=UTC)
+                commit_date = commit_date.isoformat(timespec="seconds")
             res = {
-                "date": commit["commit"]["author"]["date"],
+                "date": commit_date,
                 "author": commit["commit"]["author"]["name"],
                 "message": message,
                 "remote_id": commit["sha"],

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -22,7 +22,7 @@ from treeherder.etl.pushlog import HgPushlogProcess, last_push_id_from_server
 from treeherder.etl.taskcluster_pulse.handler import EXCHANGE_EVENT_MAP, handle_message
 from treeherder.model.models import Repository
 from treeherder.utils import github
-from treeherder.utils.github import fetch_api, fetch_api_full_url
+from treeherder.utils.github import compare_shas, get_commit
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -276,29 +276,42 @@ def query_data(repo_meta, commit):
     event_base_sha = repo_meta["branch"]
     # First we try with `master` being the base sha
     # e.g. https://api.github.com/repos/servo/servo/compare/master...1418c0555ff77e5a3d6cf0c6020ba92ece36be2e
-    compare_response = fetch_api(
-        f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
+    # compare_response = fetch_api(
+    #     f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
+    # )
+    compare_response = compare_shas(
+        repo_meta["owner"], repo_meta["repo"], event_base_sha, commit, get_comparison_object=True
     )
-    merge_base_commit = compare_response.get("merge_base_commit")
+    merge_base_commit = (
+        compare_response.merge_base_commit
+    )  # compare_response.get("merge_base_commit")
     if merge_base_commit:
-        commiter_date = merge_base_commit["commit"]["committer"]["date"]
+        commiter_date = (
+            merge_base_commit.commit.committer.date
+        )  # merge_base_commit["commit"]["committer"]["date"]
         # Since we don't use PushEvents that contain the "before" or "event.base.sha" fields [1]
         # we need to discover the right parent which existed in the base branch.
         # [1] https://github.com/taskcluster/taskcluster/blob/3dda0adf85619d18c5dcf255259f3e274d2be346/services/github/src/api.js#L55
-        parents = compare_response["merge_base_commit"]["parents"]
+        parents = (
+            compare_response.merge_base_commit.parents
+        )  # compare_response["merge_base_commit"]["parents"]
         if len(parents) == 1:
             parent = parents[0]
-            commit_info = fetch_api_full_url(parent["url"])
+            commit_info = get_commit(
+                repo_meta["owner"], repo_meta["repo"], parent.sha
+            )  # fetch_api_full_url(parent["url"])
             committer_date = commit_info["commit"]["committer"]["date"]
             # All commits involved in a PR share the same committer's date
-            if merge_base_commit["commit"]["committer"]["date"] == committer_date:
+            if merge_base_commit.commit.committer.date == committer_date:
                 # Recursively find the forking parent
-                event_base_sha, _ = query_data(repo_meta, parent["sha"])
+                event_base_sha, _ = query_data(repo_meta, parent.sha)
             else:
-                event_base_sha = parent["sha"]
+                event_base_sha = parent.sha
         else:
             for parent in parents:
-                _commit = fetch_api_full_url(parent["url"])
+                _commit = get_commit(
+                    repo_meta["owner"], repo_meta["repo"], parent.sha
+                )  # fetch_api_full_url(parent["url"])
                 # All commits involved in a merge share the same committer's date
                 if commiter_date != _commit["commit"]["committer"]["date"]:
                     event_base_sha = _commit["sha"]
@@ -307,12 +320,16 @@ def query_data(repo_meta, commit):
         assert event_base_sha != repo_meta["branch"]
         logger.info("We have a new base: %s", event_base_sha)
         # When using the correct event_base_sha the "commits" field will be correct
-        compare_response = fetch_api(
-            f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
-        )
+        compare_response = compare_shas(
+            repo_meta["owner"],
+            repo_meta["repo"],
+            event_base_sha,
+            commit,
+            get_comparison_object=True,
+        )  # fetch_api(f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}")
 
     commits = []
-    for _commit in compare_response["commits"]:
+    for _commit in compare_response.commits:
         commits.append(
             {
                 "message": _commit["commit"]["message"],

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -384,24 +384,24 @@ def ingest_git_pushes(project, dry_run=False):
     _repo = repo_meta(project)
     owner, repo = _repo["owner"], _repo["repo"]
     github_commits = github.get_all_commits(owner, repo)
+    logger.info("Fetched %s commits from Github", len(github_commits))
     not_push_revision = []
     push_revision = []
     push_to_date = {}
     for _commit in github_commits:
-        info = github.get_commit(owner, repo, _commit["sha"])
         # Revisions that are marked as non-push should be ignored
         if _commit["sha"] in not_push_revision:
             logger.debug("Not a revision of a push: {}".format(_commit["sha"]))
             continue
 
         # Establish which revisions to ignore
-        for index, parent in enumerate(info["parents"]):
+        for index, parent in enumerate(_commit["parents"]):
             if index != 0:
                 not_push_revision.append(parent["sha"])
 
         # The 1st parent is the push from `master` from which we forked
-        oldest_parent_revision = info["parents"][0]["sha"]
-        push_to_date[oldest_parent_revision] = info["commit"]["committer"]["date"]
+        oldest_parent_revision = _commit["parents"][0]["sha"]
+        push_to_date[oldest_parent_revision] = _commit["commit"]["committer"]["date"]
         logger.info(
             f"Push: {oldest_parent_revision} - Date: {push_to_date[oldest_parent_revision]}"
         )

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -276,30 +276,19 @@ def query_data(repo_meta, commit):
     event_base_sha = repo_meta["branch"]
     # First we try with `master` being the base sha
     # e.g. https://api.github.com/repos/servo/servo/compare/master...1418c0555ff77e5a3d6cf0c6020ba92ece36be2e
-    # compare_response = fetch_api(
-    #     f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
-    # )
     compare_response = compare_shas(
         repo_meta["owner"], repo_meta["repo"], event_base_sha, commit, get_comparison_object=True
     )
-    merge_base_commit = (
-        compare_response.merge_base_commit
-    )  # compare_response.get("merge_base_commit")
+    merge_base_commit = compare_response.merge_base_commit
     if merge_base_commit:
-        commiter_date = (
-            merge_base_commit.commit.committer.date
-        )  # merge_base_commit["commit"]["committer"]["date"]
+        commiter_date = merge_base_commit.commit.committer.date
         # Since we don't use PushEvents that contain the "before" or "event.base.sha" fields [1]
         # we need to discover the right parent which existed in the base branch.
         # [1] https://github.com/taskcluster/taskcluster/blob/3dda0adf85619d18c5dcf255259f3e274d2be346/services/github/src/api.js#L55
-        parents = (
-            compare_response.merge_base_commit.parents
-        )  # compare_response["merge_base_commit"]["parents"]
+        parents = compare_response.merge_base_commit.parents
         if len(parents) == 1:
             parent = parents[0]
-            commit_info = get_commit(
-                repo_meta["owner"], repo_meta["repo"], parent.sha
-            )  # fetch_api_full_url(parent["url"])
+            commit_info = get_commit(repo_meta["owner"], repo_meta["repo"], parent.sha)
             committer_date = commit_info["commit"]["committer"]["date"]
             # All commits involved in a PR share the same committer's date
             if merge_base_commit.commit.committer.date == committer_date:
@@ -309,9 +298,7 @@ def query_data(repo_meta, commit):
                 event_base_sha = parent.sha
         else:
             for parent in parents:
-                _commit = get_commit(
-                    repo_meta["owner"], repo_meta["repo"], parent.sha
-                )  # fetch_api_full_url(parent["url"])
+                _commit = get_commit(repo_meta["owner"], repo_meta["repo"], parent.sha)
                 # All commits involved in a merge share the same committer's date
                 if commiter_date != _commit["commit"]["committer"]["date"]:
                     event_base_sha = _commit["sha"]
@@ -326,16 +313,21 @@ def query_data(repo_meta, commit):
             event_base_sha,
             commit,
             get_comparison_object=True,
-        )  # fetch_api(f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}")
+        )
 
     commits = []
     for _commit in compare_response.commits:
+        author = _commit.commit.author
+        committer = _commit.commit.committer
         commits.append(
             {
-                "message": _commit["commit"]["message"],
-                "author": _commit["commit"]["author"],
-                "committer": _commit["commit"]["committer"],
-                "id": _commit["sha"],
+                "message": _commit.commit.message,
+                "author": {
+                    "name": author.name if author else None,
+                    "email": author.email if author else None,
+                },
+                "committer": {"date": committer.date if committer else None},
+                "id": _commit.sha,
             }
         )
 

--- a/treeherder/etl/push_loader.py
+++ b/treeherder/etl/push_loader.py
@@ -103,8 +103,16 @@ class GithubTransformer:
         return info
 
     def process_push(self, push_data):
-        commits = push_data
-        head_commit = commits[-1]
+        revisions = []
+        for commit in push_data:
+            revisions.append(
+                {
+                    "comment": commit.commit.message,
+                    "author": f"{commit.commit.author.name} <{commit.commit.author.email}>",
+                    "revision": commit.sha,
+                }
+            )
+        head_commit = revisions.pop()
         push = {
             "revision": head_commit.sha,
             # A push can be co-authored
@@ -113,19 +121,8 @@ class GithubTransformer:
             "push_timestamp": head_commit.commit.committer.date.timestamp(),
             # We want the original author's email to show up in the UI
             "author": head_commit.commit.author.email,
+            "revisions": revisions,
         }
-
-        revisions = []
-        for commit in commits:
-            revisions.append(
-                {
-                    "comment": commit.commit.message,
-                    "author": f"{commit.commit.author.name} <{commit.commit.author.email}>",
-                    "revision": commit.sha,
-                }
-            )
-
-        push["revisions"] = revisions
         return push
 
 

--- a/treeherder/etl/push_loader.py
+++ b/treeherder/etl/push_loader.py
@@ -104,6 +104,7 @@ class GithubTransformer:
 
     def process_push(self, push_data):
         revisions = []
+        head_commit = None
         for commit in push_data:
             revisions.append(
                 {
@@ -112,7 +113,7 @@ class GithubTransformer:
                     "revision": commit.sha,
                 }
             )
-        head_commit = revisions.pop()
+            head_commit = commit
         push = {
             "revision": head_commit.sha,
             # A push can be co-authored

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -4,29 +4,12 @@ from github import Auth, Github
 from github.GitRelease import GitRelease
 
 from treeherder.config.settings import GITHUB_TOKEN
-from treeherder.utils.http import fetch_json
 
 if GITHUB_TOKEN:
     auth = Auth.Token(GITHUB_TOKEN)
     github = Github(auth=auth)
 else:
     github = Github()
-
-
-def fetch_api(path, params=None):
-    return fetch_api_full_url(f"https://api.github.com/{path}", params)
-
-
-def fetch_api_full_url(url, params=None):
-    if GITHUB_TOKEN:
-        headers = {"Authorization": f"token {GITHUB_TOKEN}"}
-    else:
-        headers = {}
-    return fetch_json(url, params, headers)
-
-
-def get_repo(owner, repo, params=None):
-    return fetch_api(f"{owner}/{repo}", params)
 
 
 def pygithub_get_repo(owner, repo):
@@ -87,7 +70,48 @@ def compare_shas(owner, repo, base, head, get_comparison_object=False):
 
 
 def get_all_commits(owner, repo, params=None):
-    return fetch_api(f"repos/{owner}/{repo}/commits", params)
+    """
+    Retrieve GitHub commits for a given repository.
+    Returns a list of standardized dictionaries representing commits.
+    """
+    repo_object = pygithub_get_repo(owner, repo)
+    since_dt = None
+    max_number = None
+
+    if params:
+        max_number = params.get("number")
+        since_dt = params.get("since", None)
+        if since_dt:
+            since_dt = datetime.fromisoformat(since_dt)
+            if since_dt.tzinfo is None:
+                since_dt = since_dt.replace(tzinfo=UTC)
+
+    if since_dt:
+        paginated_commits = repo_object.get_commits(since=since_dt)
+    else:
+        paginated_commits = repo_object.get_commits()
+
+    commits = []
+    for commit in paginated_commits:
+        if max_number and len(commits) >= max_number:
+            break
+
+        author = commit.commit.author
+        commits.append(
+            {
+                "sha": commit.sha,
+                "html_url": commit.html_url,
+                "commit": {
+                    "message": commit.commit.message,
+                    "author": {
+                        "name": author.name if author else "unknown",
+                        "date": author.date if author else None,
+                    },
+                },
+            }
+        )
+
+    return commits
 
 
 def get_commit(owner, repo, sha, params=None):
@@ -97,7 +121,7 @@ def get_commit(owner, repo, sha, params=None):
     """
     repo_object = pygithub_get_repo(owner, repo)
     commit = repo_object.get_commit(sha)
-    commit_dict = {}
+    commit_dict = {"sha": commit.sha}
 
     # Append file objects required by collector.py
     commit_dict["files"] = []

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -5,15 +5,23 @@ from github.GitRelease import GitRelease
 
 from treeherder.config.settings import GITHUB_TOKEN
 
+# Fetch 100 items per page (GitHub's max) so changelog/ingest need fewer round trips
+# than PyGithub's default of 30. Disable PyGithub's 250ms inter-request sleep so
+# behaviour matches the previous fetch_json client; GitHub rate limits still apply.
+_github_kwargs = {
+    "per_page": 100,
+    "seconds_between_requests": None,
+    "seconds_between_writes": None,
+}
 if GITHUB_TOKEN:
-    auth = Auth.Token(GITHUB_TOKEN)
-    github = Github(auth=auth)
+    github = Github(auth=Auth.Token(GITHUB_TOKEN), **_github_kwargs)
 else:
-    github = Github()
+    github = Github(**_github_kwargs)
 
 
 def pygithub_get_repo(owner, repo):
-    return github.get_repo(f"{owner}/{repo}")
+    # lazy=True avoids an extra GET /repos/{owner}/{repo} on every helper call.
+    return github.get_repo(f"{owner}/{repo}", lazy=True)
 
 
 def get_releases(owner, repo, params=None):
@@ -97,6 +105,7 @@ def get_all_commits(owner, repo, params=None):
             break
 
         author = commit.commit.author
+        committer = commit.commit.committer
         commits.append(
             {
                 "sha": commit.sha,
@@ -107,7 +116,11 @@ def get_all_commits(owner, repo, params=None):
                         "name": author.name if author else "unknown",
                         "date": author.date if author else None,
                     },
+                    "committer": {"date": committer.date if committer else None},
                 },
+                # List-commits payloads include parents; ingest git-pushes can use
+                # these instead of issuing a get_commit() per SHA.
+                "parents": [{"sha": parent.sha} for parent in commit.parents],
             }
         )
 

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -78,10 +78,13 @@ def get_releases(owner, repo, params=None):
     return releases
 
 
-def compare_shas(owner, repo, base, head):
+def compare_shas(owner, repo, base, head, commit_count=None):
     repo = pygithub_get_repo(owner, repo)
-    comparison = repo.compare(base, head)
-    return [commit for commit in comparison.commits]
+    if commit_count is None:
+        comparison = repo.compare(base, head)
+    else:
+        comparison = repo.compare(base, head, comparison_commits_per_page=commit_count)
+    return (commit for commit in comparison.commits)
 
 
 def get_all_commits(owner, repo, params=None):
@@ -119,4 +122,4 @@ def get_pull_request(owner, repo, pr_id):
 
 def get_pull_request_commits(owner, repo, pr_id):
     pr = get_pull_request(owner, repo, pr_id)
-    return [commit for commit in pr.get_commits()]
+    return (commit for commit in pr.get_commits())

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -78,12 +78,11 @@ def get_releases(owner, repo, params=None):
     return releases
 
 
-def compare_shas(owner, repo, base, head, commit_count=None):
+def compare_shas(owner, repo, base, head, get_comparison_object=False):
     repo = pygithub_get_repo(owner, repo)
-    if commit_count is None:
-        comparison = repo.compare(base, head)
-    else:
-        comparison = repo.compare(base, head, comparison_commits_per_page=commit_count)
+    comparison = repo.compare(base, head)
+    if get_comparison_object:
+        return comparison
     return (commit for commit in comparison.commits)
 
 


### PR DESCRIPTION
Updated github.py to return generators instead of lists for:
- `get_pull_request_commits`
- `compare_shas`

Also, updated the `compare_shas` to use default parameter for comparsion count.