### PR TITLE
Cap Playwright workers in CI to match the 4-vCPU executor

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,6 +8,10 @@ module.exports = defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
+  // CI containers report the host's CPU count rather than the executor's
+  // cgroup limit, so Playwright's default (cores / 2) massively oversubscribes
+  // the 4-vCPU CircleCI executor and the run hangs. Pin workers to match it.
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI
     ? [
         ['list'],


### PR DESCRIPTION
## Problem

The `javascript-integration-tests` CircleCI job hangs: all tests start but none ever complete, and the job dies on CircleCI's no-output timeout. The log shows `Running 19 tests using 18 workers`.

## Root cause

Playwright defaults its worker count to half of `os.cpus().length`. Inside a CircleCI Docker container, Node reports the **host machine's** CPU count (36) rather than the executor's cgroup limit, so Playwright spawned 18 concurrent Firefox instances plus the rspack dev server on a 4-vCPU (`resource_class: large`) container. The oversubscription was severe enough that no test ever finished.

## Fix

Pin `workers: 4` when `CI` is set, matching the executor's vCPU count. Local runs keep Playwright's default (based on the developer machine's real core count).

## Verification

- `CI=1 pnpm test:integration` locally: 19/19 passed in 8.3s using the capped worker path
- Plain `pnpm test:integration`: 19/19 passed, developer workflow unchanged