### PR TITLE
Bug-2038705: Migrate get_all_commits to PyGithub

### DIFF
--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -1,11 +1,7 @@
 import binascii
-import json
 import os
-import re
 from datetime import UTC, datetime, timedelta
 from unittest import mock
-
-import responses
 
 from treeherder.changelog.collector import collect
 
@@ -14,44 +10,7 @@ def random_id():
     return binascii.hexlify(os.urandom(16)).decode("utf8")
 
 
-COMMITS = re.compile(r"https://api.github.com/repos/.*/.*/commits\?.*")
-COMMIT_INFO = re.compile(r"https://api.github.com/repos/.*/.*/commits/.*")
-
-
-def prepare_responses():
-    now = datetime.now(tz=UTC).isoformat(timespec="seconds")
-
-    def _commit():
-        files = [{"filename": "file1"}, {"filename": "file2"}]
-        return {
-            "files": files,
-            "name": "ok",
-            "sha": random_id(),
-            "html_url": "url",
-            "tag_name": "some tag",
-            "commit": {
-                "message": "yeah",
-                "author": {"name": "tarek", "date": now},
-                "files": files,
-            },
-        }
-
-    def commits(request):
-        return 200, {}, json.dumps([_commit()])
-
-    responses.add_callback(
-        responses.GET, COMMITS, callback=commits, content_type="application/json"
-    )
-
-
-@responses.activate
-@mock.patch("treeherder.utils.github.pygithub_get_repo")
-def test_collect(mock_pygithub_get_repo):
-    now = datetime.now(tz=UTC)
-    yesterday = now - timedelta(days=1)
-    yesterday_str = yesterday.isoformat(timespec="seconds")
-
-    # Mock the GitRelease object structure expected by collector.py
+def _mock_repo(now):
     mock_author = mock.Mock()
     mock_author.login = "mock_tarek_release"
     mock_release = mock.Mock()
@@ -62,31 +21,55 @@ def test_collect(mock_pygithub_get_repo):
     mock_release.html_url = "mock_release_url"
     mock_release.author = mock_author
 
-    # Mock the file and commit object
     mock_file1 = mock.Mock()
     mock_file1.filename = "file1"
     mock_file2 = mock.Mock()
     mock_file2.filename = "file2"
 
-    mock_commit = mock.Mock()
-    mock_commit.files = [mock_file1, mock_file2]
-    mock_commit.commit.committer.date = now.isoformat()
+    mock_commit_detail = mock.Mock()
+    mock_commit_detail.files = [mock_file1, mock_file2]
+    mock_commit_detail.commit.committer.date = now.isoformat()
     mock_parent = mock.Mock()
     mock_parent.sha = "mock_parent_sha"
-    mock_commit.parents = [mock_parent]
+    mock_commit_detail.parents = [mock_parent]
+
+    mock_git_author = mock.Mock()
+    mock_git_author.name = "tarek"
+    mock_git_author.date = now.isoformat()
+    mock_git_commit_inner = mock.Mock()
+    mock_git_commit_inner.message = "yeah"
+    mock_git_commit_inner.author = mock_git_author
+    mock_git_commit_inner.committer = mock.Mock()
+    mock_git_commit_inner.committer.date = now.isoformat()
+
+    mock_git_commit = mock.Mock()
+    mock_git_commit.sha = random_id()
+    mock_git_commit.html_url = "url"
+    mock_git_commit.commit = mock_git_commit_inner
 
     mock_repo = mock.Mock()
     mock_repo.get_releases.return_value = [mock_release]
-    mock_repo.get_commit.return_value = mock_commit
+    mock_repo.get_commits.return_value = [mock_git_commit]
+    mock_repo.get_commit.return_value = mock_commit_detail
+    return mock_repo
+
+
+@mock.patch("treeherder.utils.github.pygithub_get_repo")
+def test_collect(mock_pygithub_get_repo):
+    now = datetime.now(tz=UTC)
+    yesterday = now - timedelta(days=1)
+    yesterday_str = yesterday.isoformat(timespec="seconds")
+
+    mock_repo = _mock_repo(now)
     mock_pygithub_get_repo.return_value = mock_repo
 
-    prepare_responses()
     res = list(collect(yesterday_str))
 
-    # Assertions to ensure both release and commit data are collected
     assert len(res) > 0
+    mock_repo.get_commits.assert_called()
+    since_arg = mock_repo.get_commits.call_args.kwargs.get("since")
+    assert since_arg == datetime.fromisoformat(yesterday_str)
 
-    # Verify a release entry created from the mock PyGithub object
     release_entry = next((item for item in res if item["type"] == "release"), None)
     assert release_entry is not None
     assert release_entry["author"] == "mock_tarek_release"
@@ -95,7 +78,6 @@ def test_collect(mock_pygithub_get_repo):
     assert release_entry["url"] == "mock_release_url"
     assert release_entry["date"] == now.isoformat(timespec="seconds")
 
-    # Verify a commit entry created from responses mock
     commit_entry = next((item for item in res if item["type"] == "commit"), None)
     assert commit_entry is not None
     assert commit_entry["author"] == "tarek"

--- a/tests/changelog/test_collector.py
+++ b/tests/changelog/test_collector.py
@@ -54,14 +54,14 @@ def _mock_repo(now):
     return mock_repo
 
 
-@mock.patch("treeherder.utils.github.pygithub_get_repo")
-def test_collect(mock_pygithub_get_repo):
+@mock.patch("treeherder.utils.github.get_repo")
+def test_collect(mock_get_repo):
     now = datetime.now(tz=UTC)
     yesterday = now - timedelta(days=1)
     yesterday_str = yesterday.isoformat(timespec="seconds")
 
     mock_repo = _mock_repo(now)
-    mock_pygithub_get_repo.return_value = mock_repo
+    mock_get_repo.return_value = mock_repo
 
     res = list(collect(yesterday_str))
 

--- a/tests/changelog/test_tasks.py
+++ b/tests/changelog/test_tasks.py
@@ -2,54 +2,21 @@ from datetime import UTC, datetime
 from unittest import mock
 
 import pytest
-import responses
 
-from tests.changelog.test_collector import prepare_responses
+from tests.changelog.test_collector import _mock_repo
 from treeherder.changelog.models import Changelog
 from treeherder.changelog.tasks import update_changelog
 
 
 @pytest.mark.django_db()
-@responses.activate
 @mock.patch("treeherder.utils.github.pygithub_get_repo")
 def test_update_changelog(mock_pygithub_get_repo):
-    # Mock the GitRelease object structure expected by collector.py
     now = datetime.now(tz=UTC)
-    mock_author = mock.Mock()
-    mock_author.login = "mock_tarek_release"
-    mock_release = mock.Mock()
-    mock_release.name = "mock_release_name"
-    mock_release.tag_name = "mock_release_tag"
-    mock_release.published_at = now
-    mock_release.id = "mock_release_id_123"
-    mock_release.html_url = "mock_release_url"
-    mock_release.author = mock_author
+    mock_pygithub_get_repo.return_value = _mock_repo(now)
 
-    mock_file1 = mock.Mock()
-    mock_file1.filename = "file1"
-    mock_file2 = mock.Mock()
-    mock_file2.filename = "file2"
-
-    mock_commit = mock.Mock()
-    mock_commit.files = [mock_file1, mock_file2]
-    mock_commit.commit.committer.date = now.isoformat()
-    mock_parent = mock.Mock()
-    mock_parent.sha = "mock_parent_sha"
-    mock_commit.parents = [mock_parent]
-
-    mock_repo = mock.Mock()
-    mock_repo.get_releases.return_value = [mock_release]
-    mock_repo.get_commit.return_value = mock_commit
-    mock_pygithub_get_repo.return_value = mock_repo
-
-    prepare_responses()
     num_entries = Changelog.objects.count()
 
     update_changelog()
 
-    # we're not looking into much details here, we can do this
-    # once we start to tweak the filters
     assert Changelog.objects.count() > num_entries
-
-    # Also verify that at least one release entry was created
     assert Changelog.objects.filter(type="release", remote_id="mock_release_id_123").exists()

--- a/tests/changelog/test_tasks.py
+++ b/tests/changelog/test_tasks.py
@@ -9,10 +9,10 @@ from treeherder.changelog.tasks import update_changelog
 
 
 @pytest.mark.django_db()
-@mock.patch("treeherder.utils.github.pygithub_get_repo")
-def test_update_changelog(mock_pygithub_get_repo):
+@mock.patch("treeherder.utils.github.get_repo")
+def test_update_changelog(mock_get_repo):
     now = datetime.now(tz=UTC)
-    mock_pygithub_get_repo.return_value = _mock_repo(now)
+    mock_get_repo.return_value = _mock_repo(now)
 
     num_entries = Changelog.objects.count()
 

--- a/tests/etl/test_ingest_command.py
+++ b/tests/etl/test_ingest_command.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from treeherder.etl.management.commands import ingest
 
 REPO_META = {
@@ -9,56 +11,57 @@ REPO_META = {
 }
 
 
-def test_query_data_consumes_compare_dict(monkeypatch):
-    """query_data must read the GitHub compare REST response as a dict.
+def _git_user(name=None, email=None, date=None):
+    return SimpleNamespace(name=name, email=email, date=date)
 
-    Regression guard for Bug 2009865, which switched ``compare_shas`` to return
-    a list of PyGithub commit objects (for the Pulse push loader) but left
-    query_data doing dict access (``.get("merge_base_commit")`` / ``["commits"]``),
-    breaking the ``ingest push`` command for GitHub repos.
+
+def _commit(sha, *, message=None, author=None, committer=None, parents=None):
+    return SimpleNamespace(
+        sha=sha,
+        commit=SimpleNamespace(message=message, author=author, committer=committer),
+        parents=parents or [],
+    )
+
+
+def test_query_data_uses_pygithub_comparison(monkeypatch):
+    """query_data reads a PyGithub Comparison (Bug 2009865: not a REST dict).
+
+    compare_shas still returns commit objects for the Pulse push loader; ingest
+    uses get_comparison for merge_base_commit / parents / commits.
     """
-    compare_by_range = {
-        # base branch vs head: the head isn't on the base branch, so the API
-        # reports a merge base whose parent is the real fork point.
-        "main...HEAD": {
-            "merge_base_commit": {
-                "sha": "BASE",
-                "commit": {"committer": {"date": "2026-01-01T00:00:00Z"}},
-                "parents": [
-                    {
-                        "sha": "PARENT",
-                        "url": "https://api.github.com/repos/o/r/commits/PARENT",
-                    }
-                ],
-            },
-            "commits": [],
-        },
-        # re-compare with the corrected base yields the push's commits
-        "PARENT...HEAD": {
-            "merge_base_commit": {"sha": "PARENT", "parents": []},
-            "commits": [
-                {
-                    "sha": "C1",
-                    "commit": {
-                        "message": "Fix the thing",
-                        "author": {"name": "Dev", "email": "dev@example.com"},
-                        "committer": {"date": "2026-02-02T00:00:00Z"},
-                    },
-                }
-            ],
-        },
+    parent = _commit("PARENT")
+    merge_base = _commit(
+        "BASE",
+        committer=_git_user(date="2026-01-01T00:00:00Z"),
+        parents=[parent],
+    )
+    head_commit = _commit(
+        "C1",
+        message="Fix the thing",
+        author=_git_user(name="Dev", email="dev@example.com"),
+        committer=_git_user(date="2026-02-02T00:00:00Z"),
+    )
+
+    comparisons = {
+        ("main", "HEAD"): SimpleNamespace(merge_base_commit=merge_base, commits=[]),
+        ("PARENT", "HEAD"): SimpleNamespace(
+            merge_base_commit=_commit("PARENT", parents=[]),
+            commits=[head_commit],
+        ),
     }
 
-    def fake_fetch_api(path, params=None):
-        return compare_by_range[path.split("/compare/")[1]]
+    def fake_get_comparison(owner, repo, base, head):
+        assert owner == "o" and repo == "r"
+        return comparisons[(base, head)]
 
-    def fake_fetch_api_full_url(url, params=None):
-        # The merge-base parent, with a committer date different from the merge
-        # base so query_data takes the simple (non-recursive) branch.
+    def fake_get_commit(owner, repo, sha):
+        assert sha == "PARENT"
+        # Different committer date from the merge base so query_data takes
+        # the simple (non-recursive) branch.
         return {"sha": "PARENT", "commit": {"committer": {"date": "2026-02-02T00:00:00Z"}}}
 
-    monkeypatch.setattr(ingest, "fetch_api", fake_fetch_api)
-    monkeypatch.setattr(ingest, "fetch_api_full_url", fake_fetch_api_full_url)
+    monkeypatch.setattr(ingest, "get_comparison", fake_get_comparison)
+    monkeypatch.setattr(ingest, "get_commit", fake_get_commit)
 
     event_base_sha, commits = ingest.query_data(REPO_META, "HEAD")
 
@@ -67,7 +70,7 @@ def test_query_data_consumes_compare_dict(monkeypatch):
         {
             "message": "Fix the thing",
             "author": {"name": "Dev", "email": "dev@example.com"},
-            "committer": {"date": "2026-02-02T00:00:00Z"},
+            "committer": {"name": None, "email": None, "date": "2026-02-02T00:00:00Z"},
             "id": "C1",
         }
     ]

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -174,7 +174,7 @@ def test_get_releases_no_params(mock_github):
     mock_github.get_repo.return_value = mock_repo_instance
 
     # Call the function under test without any params
-    result = get_releases(owner, repo)
+    result = list(get_releases(owner, repo))
 
     # Construct the expected output list of dictionaries (should be in the order they were processed)
     expected_result = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
@@ -210,7 +210,7 @@ def test_get_releases_with_number_param(mock_github):
     # It adds R3, then R2. max_number is 2, so it breaks after R2.
     # Result should be [R3_dict, R2_dict]
     params = {"number": 2}
-    result = get_releases(owner, repo, params)
+    result = list(get_releases(owner, repo, params))
 
     expected_result_2 = [r.to_expected_dict() for r in all_mock_releases_input_for_repo[:2]]
     assert len(result) == 2
@@ -221,7 +221,7 @@ def test_get_releases_with_number_param(mock_github):
     # All are added, as number limit is 10.
     # Result should be [R3_dict, R2_dict, R1_dict]
     params_large_number = {"number": 10}
-    result_large_number = get_releases(owner, repo, params_large_number)
+    result_large_number = list(get_releases(owner, repo, params_large_number))
     expected_result_large = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
     assert len(result_large_number) == 3
     assert result_large_number == expected_result_large
@@ -256,7 +256,7 @@ def test_get_releases_with_since_param(mock_github):
     # Result: [R3_dict, R2_dict]
     since_date_str = "2023-01-05T12:00:00+00:00"
     params = {"since": since_date_str}
-    result = get_releases(owner, repo, params)
+    result = list(get_releases(owner, repo, params))
 
     expected_result = [
         mock_release_3_input.to_expected_dict(),
@@ -271,7 +271,7 @@ def test_get_releases_with_since_param(mock_github):
     # Result: []
     since_date_str_later = "2023-01-15T00:00:00+00:00"
     params_later = {"since": since_date_str_later}
-    result_later = get_releases(owner, repo, params_later)
+    result_later = list(get_releases(owner, repo, params_later))
     assert len(result_later) == 0
     assert result_later == []
 
@@ -283,7 +283,7 @@ def test_get_releases_with_since_param(mock_github):
     # Result: [R3_dict, R2_dict, R1_dict]
     since_date_str_earlier = "2022-12-31T00:00:00+00:00"
     params_earlier = {"since": since_date_str_earlier}
-    result_earlier = get_releases(owner, repo, params_earlier)
+    result_earlier = list(get_releases(owner, repo, params_earlier))
     expected_result_earlier = [r.to_expected_dict() for r in all_mock_releases_input_for_repo]
     assert len(result_earlier) == 3
     assert result_earlier == expected_result_earlier
@@ -332,7 +332,7 @@ def test_get_releases_with_number_and_since_params(mock_github):
     # Then apply 'number': take first 3 from this list.
     # Expected: [R5_dict, R4_dict, R3_dict]
     params_s1 = {"since": "2023-01-05T12:00:00+00:00", "number": 3}
-    result_s1 = get_releases(owner, repo, params_s1)
+    result_s1 = list(get_releases(owner, repo, params_s1))
     expected_s1 = [
         _mock_release_5_input.to_expected_dict(),
         _mock_release_4_input.to_expected_dict(),
@@ -349,7 +349,7 @@ def test_get_releases_with_number_and_since_params(mock_github):
     # Then apply 'number' (1):
     # Expected: []
     params_s2 = {"since": "2023-01-20T18:00:01+00:00", "number": 1}
-    result_s2 = get_releases(owner, repo, params_s2)
+    result_s2 = list(get_releases(owner, repo, params_s2))
     assert len(result_s2) == 0
     assert result_s2 == []
 
@@ -364,7 +364,7 @@ def test_get_releases_with_number_and_since_params(mock_github):
     # Then apply 'number' (100):
     # Expected: [R5_dict, R4_dict, R3_dict]
     params_s3 = {"since": "2023-01-10T14:00:00+00:00", "number": 100}
-    result_s3 = get_releases(owner, repo, params_s3)
+    result_s3 = list(get_releases(owner, repo, params_s3))
     expected_s3 = [
         _mock_release_5_input.to_expected_dict(),
         _mock_release_4_input.to_expected_dict(),

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 # Import the function to be tested
-from treeherder.utils.github import get_releases
+from treeherder.utils.github import get_all_commits, get_releases
 
 
 # Mock GitCommit and it's related classes
@@ -23,15 +23,24 @@ class MockCommitter:
         self.date = date
 
 
+class MockGitAuthor:
+    def __init__(self, date, name="author"):
+        self.date = date
+        self.name = name
+
+
 class MockInnerCommit:
-    def __init__(self, committer_date):
+    def __init__(self, committer_date, author_name="author", message=""):
         self.committer = MockCommitter(committer_date)
+        self.author = MockGitAuthor(committer_date, author_name)
+        self.message = message
 
 
 class MockCommit:
-    def __init__(self, sha, committer_date, parents=None, files=None):
+    def __init__(self, sha, committer_date, parents=None, files=None, html_url=None, message=""):
         self.sha = sha
-        self.commit = MockInnerCommit(committer_date)
+        self.html_url = html_url or f"https://github.com/mock-owner/mock-repo/commit/{sha}"
+        self.commit = MockInnerCommit(committer_date, message=message)
         self.parents = [MockCommitParent(p_sha) for p_sha in parents] if parents else []
         self.files = [MockCommitFile(f_name) for f_name in files] if files else []
 
@@ -46,9 +55,13 @@ def github_commit_mock():
         mock_repo = MockRepository()
         mock_github.get_repo.return_value = mock_repo
 
-        def _register(sha, committer_date, parents=None, files=None):
+        def _register(sha, committer_date, parents=None, files=None, message=""):
             commit_obj = MockCommit(
-                sha=sha, committer_date=committer_date, parents=parents, files=files
+                sha=sha,
+                committer_date=committer_date,
+                parents=parents,
+                files=files,
+                message=message,
             )
             mock_repo._commits[sha] = commit_obj
             return mock_github, mock_repo, commit_obj
@@ -126,6 +139,9 @@ class MockRepository:
 
     def get_commit(self, sha):
         return self._commits[sha]
+
+    def get_commits(self, since=None):
+        return list(self._commits.values())
 
 
 @patch("treeherder.utils.github.github")
@@ -431,3 +447,100 @@ def test_get_commit_no_files(github_commit_mock):
         "commit": {"committer": {"date": date_str}},
         "parents": [{"sha": "parentsha"}],
     }
+
+
+def _register_list_commits(mock_github, commits):
+    mock_repo = MockRepository()
+    mock_github.get_repo.return_value = mock_repo
+    for commit in commits:
+        mock_repo._commits[commit.sha] = commit
+    return mock_repo
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_no_params(mock_github):
+    """get_all_commits returns dicts matching the GitHub list-commits shape."""
+    owner = "test-owner"
+    repo = "test-repo"
+    c1 = MockCommit("sha1", datetime(2023, 1, 10, tzinfo=UTC), message="second")
+    c2 = MockCommit("sha2", datetime(2023, 1, 5, tzinfo=UTC), message="first")
+    _register_list_commits(mock_github, [c1, c2])
+
+    result = list(get_all_commits(owner, repo))
+
+    mock_github.get_repo.assert_called_once_with(f"{owner}/{repo}")
+    assert [c["sha"] for c in result] == ["sha1", "sha2"]
+    assert result[0]["html_url"] == c1.html_url
+    assert result[0]["commit"]["message"] == "second"
+    assert result[0]["commit"]["author"]["name"] == "author"
+    assert result[0]["commit"]["author"]["date"] == c1.commit.author.date
+    assert result[0]["commit"]["committer"]["date"] == c1.commit.committer.date
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_number_param(mock_github):
+    """Collector gh_options `number` limits how many commits are yielded."""
+    owner = "test-owner"
+    repo = "test-repo"
+    commits = [
+        MockCommit(f"sha{i}", datetime(2023, 1, 10 - i, tzinfo=UTC), message=f"c{i}")
+        for i in range(5)
+    ]
+    mock_repo = _register_list_commits(mock_github, commits)
+    mock_repo.get_commits = lambda **kwargs: commits
+
+    result = list(get_all_commits(owner, repo, params={"number": 2}))
+
+    assert [c["sha"] for c in result] == ["sha0", "sha1"]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_since_param(mock_github):
+    """Collector gh_options `since` is passed to PyGithub as a datetime."""
+    owner = "test-owner"
+    repo = "test-repo"
+    since_commit = MockCommit("new", datetime(2023, 1, 10, tzinfo=UTC), message="new")
+    mock_repo = MockRepository()
+    mock_github.get_repo.return_value = mock_repo
+
+    captured = {}
+
+    def capture_get_commits(**kwargs):
+        captured.update(kwargs)
+        return [since_commit]
+
+    mock_repo.get_commits = capture_get_commits
+    since_str = "2023-01-05T12:00:00+00:00"
+    result = list(get_all_commits(owner, repo, params={"since": since_str}))
+
+    assert captured["since"] == datetime.fromisoformat(since_str)
+    assert [c["sha"] for c in result] == ["new"]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_all_commits_with_number_and_since_params(mock_github):
+    """Both collector gh_options are applied together."""
+    owner = "test-owner"
+    repo = "test-repo"
+    newer = MockCommit("newer", datetime(2023, 1, 20, tzinfo=UTC), message="newer")
+    older = MockCommit("older", datetime(2023, 1, 10, tzinfo=UTC), message="older")
+    mock_repo = MockRepository()
+    mock_github.get_repo.return_value = mock_repo
+
+    captured = {}
+
+    def capture_get_commits(**kwargs):
+        captured.update(kwargs)
+        return [newer, older]
+
+    mock_repo.get_commits = capture_get_commits
+    result = list(
+        get_all_commits(
+            owner,
+            repo,
+            params={"since": "2023-01-05T00:00:00+00:00", "number": 1},
+        )
+    )
+
+    assert captured["since"] == datetime(2023, 1, 5, tzinfo=UTC)
+    assert [c["sha"] for c in result] == ["newer"]

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 # Import the function to be tested
-from treeherder.utils.github import get_all_commits, get_releases
+from treeherder.utils.github import compare_shas, get_all_commits, get_comparison, get_releases
 
 
 # Mock GitCommit and it's related classes
@@ -142,6 +142,14 @@ class MockRepository:
 
     def get_commits(self, since=None):
         return list(self._commits.values())
+
+    def compare(self, base, head):
+        class MockComparison:
+            def __init__(self, commits):
+                self.commits = commits
+                self.merge_base_commit = None
+
+        return MockComparison(list(self._commits.values()))
 
 
 @patch("treeherder.utils.github.github")
@@ -544,3 +552,22 @@ def test_get_all_commits_with_number_and_since_params(mock_github):
 
     assert captured["since"] == datetime(2023, 1, 5, tzinfo=UTC)
     assert [c["sha"] for c in result] == ["newer"]
+
+
+@patch("treeherder.utils.github.github")
+def test_get_comparison_and_compare_shas(mock_github):
+    """get_comparison returns the PyGithub Comparison; compare_shas stays a commit list."""
+    owner = "test-owner"
+    repo = "test-repo"
+    c1 = MockCommit("sha1", datetime(2023, 1, 10, tzinfo=UTC), message="one")
+    c2 = MockCommit("sha2", datetime(2023, 1, 5, tzinfo=UTC), message="two")
+    mock_repo = MockRepository()
+    mock_repo._commits = {"sha1": c1, "sha2": c2}
+    mock_github.get_repo.return_value = mock_repo
+
+    comparison = get_comparison(owner, repo, "base", "head")
+    mock_github.get_repo.assert_called_with(f"{owner}/{repo}")
+    assert list(comparison.commits) == [c1, c2]
+
+    result = compare_shas(owner, repo, "base", "head")
+    assert result == [c1, c2]

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -3,8 +3,12 @@ from unittest.mock import patch
 
 import pytest
 
-# Import the function to be tested
-from treeherder.utils.github import compare_shas, get_all_commits, get_comparison, get_releases
+from treeherder.utils.github import (
+    compare_shas,
+    get_all_commits,
+    get_comparison,
+    get_releases,
+)
 
 
 # Mock GitCommit and it's related classes
@@ -19,8 +23,9 @@ class MockCommitFile:
 
 
 class MockCommitter:
-    def __init__(self, date):
+    def __init__(self, date, name="author"):
         self.date = date
+        self.name = name
 
 
 class MockGitAuthor:

--- a/treeherder/etl/management/commands/ingest.py
+++ b/treeherder/etl/management/commands/ingest.py
@@ -22,7 +22,7 @@ from treeherder.etl.pushlog import HgPushlogProcess, last_push_id_from_server
 from treeherder.etl.taskcluster_pulse.handler import EXCHANGE_EVENT_MAP, handle_message
 from treeherder.model.models import Repository
 from treeherder.utils import github
-from treeherder.utils.github import fetch_api, fetch_api_full_url
+from treeherder.utils.github import get_commit, get_comparison
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -274,51 +274,58 @@ def query_data(repo_meta, commit):
     # This is used for the `compare` API. The "event.base.sha" is only contained in Pulse events, thus,
     # we need to determine the correct value
     event_base_sha = repo_meta["branch"]
+    owner, repo = repo_meta["owner"], repo_meta["repo"]
     # First we try with `master` being the base sha
     # e.g. https://api.github.com/repos/servo/servo/compare/master...1418c0555ff77e5a3d6cf0c6020ba92ece36be2e
-    compare_response = fetch_api(
-        f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
-    )
-    merge_base_commit = compare_response.get("merge_base_commit")
+    comparison = get_comparison(owner, repo, event_base_sha, commit)
+    merge_base_commit = comparison.merge_base_commit
     if merge_base_commit:
-        commiter_date = merge_base_commit["commit"]["committer"]["date"]
+        commiter_date = merge_base_commit.commit.committer.date
         # Since we don't use PushEvents that contain the "before" or "event.base.sha" fields [1]
         # we need to discover the right parent which existed in the base branch.
         # [1] https://github.com/taskcluster/taskcluster/blob/3dda0adf85619d18c5dcf255259f3e274d2be346/services/github/src/api.js#L55
-        parents = compare_response["merge_base_commit"]["parents"]
+        parents = merge_base_commit.parents
         if len(parents) == 1:
             parent = parents[0]
-            commit_info = fetch_api_full_url(parent["url"])
+            commit_info = get_commit(owner, repo, parent.sha)
             committer_date = commit_info["commit"]["committer"]["date"]
             # All commits involved in a PR share the same committer's date
-            if merge_base_commit["commit"]["committer"]["date"] == committer_date:
+            if merge_base_commit.commit.committer.date == committer_date:
                 # Recursively find the forking parent
-                event_base_sha, _ = query_data(repo_meta, parent["sha"])
+                event_base_sha, _ = query_data(repo_meta, parent.sha)
             else:
-                event_base_sha = parent["sha"]
+                event_base_sha = parent.sha
         else:
             for parent in parents:
-                _commit = fetch_api_full_url(parent["url"])
+                parent_info = get_commit(owner, repo, parent.sha)
                 # All commits involved in a merge share the same committer's date
-                if commiter_date != _commit["commit"]["committer"]["date"]:
-                    event_base_sha = _commit["sha"]
+                if commiter_date != parent_info["commit"]["committer"]["date"]:
+                    event_base_sha = parent.sha
                     break
         # This is to make sure that the value has changed
         assert event_base_sha != repo_meta["branch"]
         logger.info("We have a new base: %s", event_base_sha)
         # When using the correct event_base_sha the "commits" field will be correct
-        compare_response = fetch_api(
-            f"repos/{repo_meta['owner']}/{repo_meta['repo']}/compare/{event_base_sha}...{commit}"
-        )
+        comparison = get_comparison(owner, repo, event_base_sha, commit)
 
     commits = []
-    for _commit in compare_response["commits"]:
+    for _commit in comparison.commits:
+        git_commit = _commit.commit
+        author = git_commit.author
+        committer = git_commit.committer
         commits.append(
             {
-                "message": _commit["commit"]["message"],
-                "author": _commit["commit"]["author"],
-                "committer": _commit["commit"]["committer"],
-                "id": _commit["sha"],
+                "message": git_commit.message,
+                "author": {
+                    "name": author.name if author else None,
+                    "email": author.email if author else None,
+                },
+                "committer": {
+                    "name": committer.name if committer else None,
+                    "email": committer.email if committer else None,
+                    "date": committer.date if committer else None,
+                },
+                "id": _commit.sha,
             }
         )
 

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -12,11 +12,7 @@ else:
     github = Github()
 
 
-def get_repo(owner, repo, params=None):
-    return pygithub_get_repo(owner, repo)
-
-
-def pygithub_get_repo(owner, repo):
+def get_repo(owner, repo):
     return github.get_repo(f"{owner}/{repo}")
 
 
@@ -41,7 +37,7 @@ def get_releases(owner, repo, params=None):
     Retrieve GitHub releases for a given repository.
     Returns a list of standardized dictionaries representing releases.
     """
-    paginated_releases = pygithub_get_repo(owner=owner, repo=repo).get_releases()
+    paginated_releases = get_repo(owner=owner, repo=repo).get_releases()
 
     releases: list[GitRelease] = []
     max_number, since_dt = _parse_list_options(params)
@@ -74,7 +70,7 @@ def get_releases(owner, repo, params=None):
 
 def get_comparison(owner, repo, base, head):
     """Return the PyGithub Comparison for ``base...head``."""
-    return pygithub_get_repo(owner, repo).compare(base, head)
+    return get_repo(owner, repo).compare(base, head)
 
 
 def compare_shas(owner, repo, base, head):
@@ -97,7 +93,7 @@ def get_all_commits(owner, repo, params=None):
     used by collector.py and ingest.py.
     """
     max_number, since_dt = _parse_list_options(params)
-    repo_object = pygithub_get_repo(owner, repo)
+    repo_object = get_repo(owner, repo)
     kwargs = {}
     if since_dt is not None:
         kwargs["since"] = since_dt
@@ -133,7 +129,7 @@ def get_commit(owner, repo, sha, params=None):
     Retrieve GitHub commit for a given sha.
     Returns a standardized dictionary representing a commit.
     """
-    repo_object = pygithub_get_repo(owner, repo)
+    repo_object = get_repo(owner, repo)
     commit = repo_object.get_commit(sha)
     commit_dict = {}
 
@@ -153,7 +149,7 @@ def get_commit(owner, repo, sha, params=None):
 
 
 def get_pull_request(owner, repo, pr_id):
-    repo = pygithub_get_repo(owner, repo)
+    repo = get_repo(owner, repo)
     return repo.get_pull(pr_id)
 
 

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -4,25 +4,12 @@ from github import Auth, Github
 from github.GitRelease import GitRelease
 
 from treeherder.config.settings import GITHUB_TOKEN
-from treeherder.utils.http import fetch_json
 
 if GITHUB_TOKEN:
     auth = Auth.Token(GITHUB_TOKEN)
     github = Github(auth=auth)
 else:
     github = Github()
-
-
-def fetch_api(path, params=None):
-    return fetch_api_full_url(f"https://api.github.com/{path}", params)
-
-
-def fetch_api_full_url(url, params=None):
-    if GITHUB_TOKEN:
-        headers = {"Authorization": f"token {GITHUB_TOKEN}"}
-    else:
-        headers = {}
-    return fetch_json(url, params, headers)
 
 
 def get_repo(owner, repo, params=None):
@@ -85,10 +72,18 @@ def get_releases(owner, repo, params=None):
     return releases
 
 
+def get_comparison(owner, repo, base, head):
+    """Return the PyGithub Comparison for ``base...head``."""
+    return pygithub_get_repo(owner, repo).compare(base, head)
+
+
 def compare_shas(owner, repo, base, head):
-    repo = pygithub_get_repo(owner, repo)
-    comparison = repo.compare(base, head)
-    return [commit for commit in comparison.commits]
+    """Return the list of PyGithub commits between ``base`` and ``head``.
+
+    Used by push_loader. GithubPushTransformer.process_push expects commit
+    objects (``.sha``, ``.commit.committer.date``, ``.commit.author``).
+    """
+    return [commit for commit in get_comparison(owner, repo, base, head).commits]
 
 
 def get_all_commits(owner, repo, params=None):

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -26,11 +26,27 @@ def fetch_api_full_url(url, params=None):
 
 
 def get_repo(owner, repo, params=None):
-    return fetch_api(f"{owner}/{repo}", params)
+    return pygithub_get_repo(owner, repo)
 
 
 def pygithub_get_repo(owner, repo):
     return github.get_repo(f"{owner}/{repo}")
+
+
+def _parse_list_options(params):
+    """Parse collector-style gh_options (`number`, `since`) for list endpoints."""
+    max_number = None
+    since_dt = None
+    if not params:
+        return max_number, since_dt
+
+    max_number = params.get("number")
+    since_dt = params.get("since")
+    if since_dt is not None and not isinstance(since_dt, datetime):
+        since_dt = datetime.fromisoformat(since_dt)
+    if isinstance(since_dt, datetime) and since_dt.tzinfo is None:
+        since_dt = since_dt.replace(tzinfo=UTC)
+    return max_number, since_dt
 
 
 def get_releases(owner, repo, params=None):
@@ -41,16 +57,7 @@ def get_releases(owner, repo, params=None):
     paginated_releases = pygithub_get_repo(owner=owner, repo=repo).get_releases()
 
     releases: list[GitRelease] = []
-    since_dt = None
-    max_number = None
-
-    if params:
-        max_number = params.get("number")
-        since_dt = params.get("since", None)
-        if since_dt:
-            since_dt = datetime.fromisoformat(since_dt)
-            if since_dt.tzinfo is None:
-                since_dt.replace(tzinfo=UTC)
+    max_number, since_dt = _parse_list_options(params)
 
     for release in paginated_releases:
         # Break if we have reached max_number
@@ -85,7 +92,45 @@ def compare_shas(owner, repo, base, head):
 
 
 def get_all_commits(owner, repo, params=None):
-    return fetch_api(f"repos/{owner}/{repo}/commits", params)
+    """
+    Retrieve GitHub commits for a given repository.
+
+    ``params`` accepts the same collector gh_options as ``get_releases``:
+    ``number`` (max commits to return) and ``since`` (ISO-8601 string or datetime).
+
+    Yields standardized dictionaries matching the GitHub list-commits JSON shape
+    used by collector.py and ingest.py.
+    """
+    max_number, since_dt = _parse_list_options(params)
+    repo_object = pygithub_get_repo(owner, repo)
+    kwargs = {}
+    if since_dt is not None:
+        kwargs["since"] = since_dt
+
+    count = 0
+    for commit in repo_object.get_commits(**kwargs):
+        if max_number and count >= max_number:
+            break
+
+        git_commit = commit.commit
+        author = git_commit.author if git_commit else None
+        committer = git_commit.committer if git_commit else None
+        yield {
+            "sha": commit.sha,
+            "html_url": commit.html_url,
+            "commit": {
+                "message": git_commit.message if git_commit else "",
+                "author": {
+                    "name": author.name if author else None,
+                    "date": author.date if author else None,
+                },
+                "committer": {
+                    "name": committer.name if committer else None,
+                    "date": committer.date if committer else None,
+                },
+            },
+        }
+        count += 1
 
 
 def get_commit(owner, repo, sha, params=None):

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -1,15 +1,23 @@
 from datetime import UTC, datetime
 
 from github import Auth, Github
-from github.GitRelease import GitRelease
 
 from treeherder.config.settings import GITHUB_TOKEN
 
+# per_page=100 is GitHub's max and matches collector MAX_ITEMS, so typical
+# list endpoints complete in one HTTP call (PyGithub defaults to 30).
+# lazy=True builds repo/PR objects from URLs without GET /repos or GET /pulls.
+# seconds_between_requests=0 matches the old fetch_json client (no 250ms pause).
+_GITHUB_KWARGS = {
+    "per_page": 100,
+    "lazy": True,
+    "seconds_between_requests": 0,
+}
+
 if GITHUB_TOKEN:
-    auth = Auth.Token(GITHUB_TOKEN)
-    github = Github(auth=auth)
+    github = Github(auth=Auth.Token(GITHUB_TOKEN), **_GITHUB_KWARGS)
 else:
-    github = Github()
+    github = Github(**_GITHUB_KWARGS)
 
 
 def get_repo(owner, repo):
@@ -35,18 +43,14 @@ def _parse_list_options(params):
 def get_releases(owner, repo, params=None):
     """
     Retrieve GitHub releases for a given repository.
-    Returns a list of standardized dictionaries representing releases.
+    Yields standardized dictionaries representing releases.
     """
     paginated_releases = get_repo(owner=owner, repo=repo).get_releases()
 
-    releases: list[GitRelease] = []
     max_number, since_dt = _parse_list_options(params)
+    count = 0
 
     for release in paginated_releases:
-        # Break if we have reached max_number
-        if max_number and len(releases) >= max_number:
-            break
-
         # PyGithub returns releases in reverse chronological order
         # Stop immediately if releases older than the since_dt are found
         release_dt = release.published_at
@@ -55,7 +59,7 @@ def get_releases(owner, repo, params=None):
                 release_dt.replace(tzinfo=UTC)
             if release.published_at < since_dt:
                 break
-        release_dict = {
+        yield {
             "id": release.id,
             "name": release.name,
             "tag_name": release.tag_name,
@@ -63,9 +67,9 @@ def get_releases(owner, repo, params=None):
             "html_url": release.html_url,
             "author": {"login": release.author.login if release.author else "unknown"},
         }
-        releases.append(release_dict)
-
-    return releases
+        count += 1
+        if max_number and count >= max_number:
+            break
 
 
 def get_comparison(owner, repo, base, head):
@@ -76,10 +80,10 @@ def get_comparison(owner, repo, base, head):
 def compare_shas(owner, repo, base, head):
     """Return the list of PyGithub commits between ``base`` and ``head``.
 
-    Used by push_loader. GithubPushTransformer.process_push expects commit
-    objects (``.sha``, ``.commit.committer.date``, ``.commit.author``).
+    Materialized as a list because GithubTransformer.process_push indexes
+    ``commits[-1]`` and then iterates the same sequence.
     """
-    return [commit for commit in get_comparison(owner, repo, base, head).commits]
+    return list(get_comparison(owner, repo, base, head).commits)
 
 
 def get_all_commits(owner, repo, params=None):
@@ -100,9 +104,6 @@ def get_all_commits(owner, repo, params=None):
 
     count = 0
     for commit in repo_object.get_commits(**kwargs):
-        if max_number and count >= max_number:
-            break
-
         git_commit = commit.commit
         author = git_commit.author if git_commit else None
         committer = git_commit.committer if git_commit else None
@@ -122,6 +123,8 @@ def get_all_commits(owner, repo, params=None):
             },
         }
         count += 1
+        if max_number and count >= max_number:
+            break
 
 
 def get_commit(owner, repo, sha, params=None):
@@ -154,5 +157,6 @@ def get_pull_request(owner, repo, pr_id):
 
 
 def get_pull_request_commits(owner, repo, pr_id):
+    """Return PR commits as a list (process_push needs ``commits[-1]``)."""
     pr = get_pull_request(owner, repo, pr_id)
-    return [commit for commit in pr.get_commits()]
+    return list(pr.get_commits())

--- a/treeherder/utils/github.py
+++ b/treeherder/utils/github.py
@@ -113,12 +113,12 @@ def get_all_commits(owner, repo, params=None):
             "commit": {
                 "message": git_commit.message if git_commit else "",
                 "author": {
-                    "name": author.name if author else None,
-                    "date": author.date if author else None,
+                    "name": getattr(author, "name", None),
+                    "date": getattr(author, "date", None),
                 },
                 "committer": {
-                    "name": committer.name if committer else None,
-                    "date": committer.date if committer else None,
+                    "name": getattr(committer, "name", None),
+                    "date": getattr(committer, "date", None),
                 },
             },
         }


### PR DESCRIPTION
## Summary

Finish migrating `treeherder/utils/github.py` to PyGithub and remove the REST helpers.

- `get_all_commits` uses `Repository.get_commits()`, honors collector `gh_options` (`number`, `since`), and still yields dicts for collector and ingest.
- `fetch_api` / `fetch_api_full_url` are removed; `ingest.query_data` uses `get_comparison` + `get_commit`.
- `compare_shas` still returns a list of commit objects for `push_loader` (`commits[-1]`).
- Single `get_repo` helper.

**Performance:** `Github(per_page=100, lazy=True, seconds_between_requests=0)` so PR ingest is one HTTP call (no `GET /repos` or `GET /pulls`, no 250ms pause, no extra page at 30 items). List loops break before fetching the next page.

**Generators:** `get_all_commits` and `get_releases` yield. `compare_shas` / `get_pull_request_commits` stay lists because `process_push` needs `commits[-1]`.


## Test plan

- [x] Unit tests for `get_all_commits` and `get_releases`
- [x] Changelog tests patch `get_repo`
- [x] Live PR ingest timing vs REST (lazy + per_page=100 ≈ REST)

@gmierz @Archaeopteryx 