### PR TITLE
Bug 2020493 - Replace positional args with dataclasses for readability 

### DIFF
--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -325,16 +325,14 @@ def test_grouped_perf_data_uses_single_query(
 
     # When: grouping the performance data
     with django_assert_num_queries(1):
-        grouped_job_ids, grouped_values, grouped_replicate_values = (
-            PerfCompareResults._get_grouped_perf_data(perf_data)
-        )
+        grouped = PerfCompareResults._get_grouped_perf_data(perf_data)
 
     # Then: values, job ids and replicate values are grouped as before
     sig_id = test_perf_signature.id
-    assert sorted(grouped_values[sig_id]) == [10.0, 20.0]
-    assert sorted(grouped_job_ids[sig_id]) == sorted([job1.id, job2.id])
+    assert sorted(grouped.values[sig_id]) == [10.0, 20.0]
+    assert sorted(grouped.job_ids[sig_id]) == sorted([job1.id, job2.id])
     # replicate value used when present, main value used as fallback otherwise
-    assert sorted(grouped_replicate_values[sig_id]) == [10.5, 20.0]
+    assert sorted(grouped.replicates[sig_id]) == [10.5, 20.0]
 
 
 def test_perfcompare_results_queries_perf_datum_once_per_repo(

--- a/tests/webapp/api/test_perfcompare_api.py
+++ b/tests/webapp/api/test_perfcompare_api.py
@@ -2,6 +2,8 @@ import datetime
 from unittest import skip
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from treeherder.model.models import Job
@@ -11,6 +13,7 @@ from treeherder.perf.models import (
     PerformanceDatumReplicate,
 )
 from treeherder.webapp.api import perfcompare_utils
+from treeherder.webapp.api.performance_data import PerfCompareResults
 
 pytestmark = pytest.mark.perf
 
@@ -279,6 +282,114 @@ def test_perfcompare_results_against_no_base(
     assert expected[0] == response.json()[0]
     assert response.json()[0]["base_parent_signature"] is None
     assert response.json()[0]["new_parent_signature"] is None
+
+
+def test_grouped_perf_data_uses_single_query(
+    test_perf_signature,
+    test_perfcomp_push,
+    eleven_jobs_stored,
+    django_assert_num_queries,
+):
+    """
+    Given performance datums, some of which have replicate values,
+    When _get_grouped_perf_data runs,
+    Then it issues a single query while preserving the grouping semantics.
+    """
+    # Given: two datums for the same signature, one with a replicate value
+    jobs = Job.objects.filter(pk__in=range(1, 11)).order_by("push__time").all()
+    job1, job2 = jobs[0], jobs[1]
+    job1.push = test_perfcomp_push
+    job1.save()
+    job2.push = test_perfcomp_push
+    job2.save()
+
+    datum1 = PerformanceDatum.objects.create(
+        value=10.0,
+        push_timestamp=test_perfcomp_push.time,
+        job=job1,
+        push=test_perfcomp_push,
+        repository=test_perf_signature.repository,
+        signature=test_perf_signature,
+    )
+    PerformanceDatum.objects.create(
+        value=20.0,
+        push_timestamp=test_perfcomp_push.time,
+        job=job2,
+        push=test_perfcomp_push,
+        repository=test_perf_signature.repository,
+        signature=test_perf_signature,
+    )
+    PerformanceDatumReplicate.objects.create(performance_datum=datum1, value=10.5)
+
+    perf_data = PerformanceDatum.objects.filter(signature=test_perf_signature)
+
+    # When: grouping the performance data
+    with django_assert_num_queries(1):
+        grouped_job_ids, grouped_values, grouped_replicate_values = (
+            PerfCompareResults._get_grouped_perf_data(perf_data)
+        )
+
+    # Then: values, job ids and replicate values are grouped as before
+    sig_id = test_perf_signature.id
+    assert sorted(grouped_values[sig_id]) == [10.0, 20.0]
+    assert sorted(grouped_job_ids[sig_id]) == sorted([job1.id, job2.id])
+    # replicate value used when present, main value used as fallback otherwise
+    assert sorted(grouped_replicate_values[sig_id]) == [10.5, 20.0]
+
+
+def test_perfcompare_results_queries_perf_datum_once_per_repo(
+    client,
+    create_signature,
+    test_perf_signature,
+    test_repository,
+    try_repository,
+    eleven_jobs_stored,
+    test_perfcomp_push,
+    test_perfcomp_push_2,
+    test_linux_platform,
+    test_option_collection,
+):
+    """
+    Given base and new performance data, each with replicate values,
+    When the perfcompare results endpoint is queried,
+    Then the performance_datum table is queried only once per repo
+    (it used to be scanned twice per repo, once per grouping pass).
+    """
+    # Given: base and new data on two repos
+    setup_mwu_compatible_data(
+        [32.4, 33.1, 31.8],
+        [40.2, 41.5, 39.8],
+        test_perfcomp_push,
+        try_repository,
+        test_perfcomp_push_2,
+        create_signature,
+        test_linux_platform,
+        test_perf_signature,
+        test_repository,
+    )
+
+    base_datum = PerformanceDatum.objects.filter(signature__repository=try_repository).first()
+    new_datum = PerformanceDatum.objects.filter(signature__repository=test_repository).first()
+    PerformanceDatumReplicate.objects.create(performance_datum=base_datum, value=30.0)
+    PerformanceDatumReplicate.objects.create(performance_datum=new_datum, value=45.0)
+
+    query_params = (
+        f"?base_repository={try_repository.name}&new_repository={test_repository.name}"
+        f"&new_revision={test_perfcomp_push_2.revision}"
+        f"&framework={test_perf_signature.framework_id}"
+        f"&interval=604800&no_subtests=true"
+    )
+
+    # When: the comparison is requested
+    with CaptureQueriesContext(connection) as captured:
+        response = client.get(reverse("perfcompare-results") + query_params)
+
+    # Then: exactly one performance_datum query per side (two total)
+    assert response.status_code == 200
+    perf_datum_queries = [
+        query["sql"] for query in captured.captured_queries if "performance_datum" in query["sql"]
+    ]
+    assert len(perf_datum_queries) == 2
 
 
 def test_perfcompare_results_with_only_one_run_and_diff_repo(

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1666,9 +1666,9 @@ class PerfCompareResults(generics.ListAPIView):
 
     @staticmethod
     def _get_signatures(repository_name, framework, parent_signature, interval, no_subtests):
-        signatures = PerformanceSignature.objects.select_related(
-            "framework", "repository", "platform", "push", "job"
-        ).filter(repository__name=repository_name)
+        signatures = PerformanceSignature.objects.select_related("repository", "platform").filter(
+            repository__name=repository_name
+        )
         signatures = signatures.filter(parent_signature__isnull=no_subtests)
         if framework:
             signatures = signatures.filter(framework__id=framework)

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1647,7 +1647,7 @@ class PerfCompareResults(generics.ListAPIView):
     @staticmethod
     def _get_perf_data(repository_name, revision, signatures, interval, startday, endday):
         signature_ids = [signature["id"] for signature in list(signatures)]
-        perf_data = PerformanceDatum.objects.select_related("push", "repository", "id").filter(
+        perf_data = PerformanceDatum.objects.select_related("push", "repository").filter(
             signature_id__in=signature_ids,
             repository__name=repository_name,
         )

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1212,6 +1212,45 @@ class _ComparisonData:
     push_timestamp: int
 
 
+@dataclass(frozen=True)
+class GroupedPerfData:
+    values: dict
+    job_ids: dict
+    replicates: dict
+
+
+@dataclass(frozen=True)
+class SignaturesMap:
+    map: dict
+    header_names: list
+    platforms: list
+
+
+@dataclass(frozen=True)
+class SignatureInfo:
+    extra_options: str
+    lower_is_better: bool | str
+    option_name: str
+    signature_hash: str
+    suite: str
+    test: str
+
+
+@dataclass(frozen=True)
+class ComparisonRow:
+    stats_base: list
+    stats_new: list
+    header: str
+    lower_is_better: bool | str
+    common: dict
+
+
+@dataclass(frozen=True)
+class MwuTask:
+    row: ComparisonRow
+    enable_silverman_kde: bool
+
+
 class PerfCompareResults(generics.ListAPIView):
     serializer_class = PerfCompareResultsSerializer
     queryset = None
@@ -1291,50 +1330,42 @@ class PerfCompareResults(generics.ListAPIView):
 
         option_collection_map = perfcompare_utils.get_option_collection_map()
 
-        (
-            base_grouped_job_ids,
-            base_grouped_values,
-            base_grouped_replicates,
-        ) = self._get_grouped_perf_data(base_perf_data)
-        (
-            new_grouped_job_ids,
-            new_grouped_values,
-            new_grouped_replicates,
-        ) = self._get_grouped_perf_data(new_perf_data)
+        base_grouped = self._get_grouped_perf_data(base_perf_data)
+        new_grouped = self._get_grouped_perf_data(new_perf_data)
 
-        statistics_base_grouped_data = base_grouped_values
-        statistics_new_grouped_data = new_grouped_values
+        statistics_base_grouped_data = base_grouped.values
+        statistics_new_grouped_data = new_grouped.values
         if replicates:
-            statistics_base_grouped_data = base_grouped_replicates
-            statistics_new_grouped_data = new_grouped_replicates
+            statistics_base_grouped_data = base_grouped.replicates
+            statistics_new_grouped_data = new_grouped.replicates
 
-        base_signatures_map, base_header_names, base_platforms = self._get_signatures_map(
+        base_signatures_map = self._get_signatures_map(
             base_signatures, statistics_base_grouped_data, option_collection_map
         )
-        new_signatures_map, new_header_names, new_platforms = self._get_signatures_map(
+        new_signatures_map = self._get_signatures_map(
             new_signatures, statistics_new_grouped_data, option_collection_map
         )
 
-        header_names = list(set(base_header_names + new_header_names))
+        header_names = list(set(base_signatures_map.header_names + new_signatures_map.header_names))
         header_names.sort()
-        platforms = set(base_platforms + new_platforms)
+        platforms = set(base_signatures_map.platforms + new_signatures_map.platforms)
         self.queryset = []
 
         base = _RepoPerfData(
-            signatures_map=base_signatures_map,
-            values=base_grouped_values,
-            replicates=base_grouped_replicates,
+            signatures_map=base_signatures_map.map,
+            values=base_grouped.values,
+            replicates=base_grouped.replicates,
             stats=statistics_base_grouped_data,
-            job_ids=base_grouped_job_ids,
+            job_ids=base_grouped.job_ids,
             rev=base_rev,
             repo_name=base_repo_name,
         )
         new = _RepoPerfData(
-            signatures_map=new_signatures_map,
-            values=new_grouped_values,
-            replicates=new_grouped_replicates,
+            signatures_map=new_signatures_map.map,
+            values=new_grouped.values,
+            replicates=new_grouped.replicates,
             stats=statistics_new_grouped_data,
-            job_ids=new_grouped_job_ids,
+            job_ids=new_grouped.job_ids,
             rev=new_rev,
             repo_name=new_repo_name,
         )
@@ -1384,47 +1415,29 @@ class PerfCompareResults(generics.ListAPIView):
 
     @staticmethod
     def _comparison_pairs(comparison_inputs, header_names, platforms):
-        """Yield each valid (header, platform) pair with its unpacked common result."""
+        """Yield a ComparisonRow for each (header, platform) pair that has results."""
         for header in header_names:
             for platform in platforms:
-                (
-                    lower_is_better,
-                    statistics_base_perf_data,
-                    statistics_new_perf_data,
-                    has_results,
-                    common_result,
-                ) = PerfCompareResults._build_common_result(comparison_inputs, header, platform)
-
-                if has_results:
-                    yield (
-                        lower_is_better,
-                        statistics_base_perf_data,
-                        statistics_new_perf_data,
-                        header,
-                        common_result,
-                    )
+                row = PerfCompareResults._build_common_result(comparison_inputs, header, platform)
+                if row is not None:
+                    yield row
 
     @staticmethod
     def _process_mann_whitney_u(comparison_inputs, header_names, platforms, enable_silverman_kde):
         """
         Process performance comparison results using Mann-Whitney U test with parallel processing.
         """
-        tasks = []
-        for (
-            lower_is_better,
-            stats_base,
-            stats_new,
-            header,
-            common,
-        ) in PerfCompareResults._comparison_pairs(comparison_inputs, header_names, platforms):
-            tasks.append(
-                (stats_base, stats_new, header, lower_is_better, common, enable_silverman_kde)
+        tasks = [
+            MwuTask(row=row, enable_silverman_kde=enable_silverman_kde)
+            for row in PerfCompareResults._comparison_pairs(
+                comparison_inputs, header_names, platforms
             )
+        ]
 
         workers = multiprocessing.cpu_count()
         logger.warning(f"Workers used for MWU analysis: {workers}")
         with multiprocessing.Pool(processes=workers) as pool:
-            results = pool.starmap(PerfCompareResults._process_mann_whitney_task, tasks)
+            results = pool.map(PerfCompareResults._process_mann_whitney_task, tasks)
 
         return results
 
@@ -1434,13 +1447,12 @@ class PerfCompareResults(generics.ListAPIView):
         Process performance comparison results using Student's t-test (sequential processing).
         """
         results = []
-        for (
-            lower_is_better,
-            stats_base,
-            stats_new,
-            header,
-            common,
-        ) in PerfCompareResults._comparison_pairs(comparison_inputs, header_names, platforms):
+        for row in PerfCompareResults._comparison_pairs(comparison_inputs, header_names, platforms):
+            lower_is_better = row.lower_is_better
+            stats_base = row.stats_base
+            stats_new = row.stats_new
+            header = row.header
+            common = row.common
             # Calculate Student's t-test specific data
             base_runs_count = len(stats_base)
             new_runs_count = len(stats_new)
@@ -1505,12 +1517,11 @@ class PerfCompareResults(generics.ListAPIView):
     @staticmethod
     def _build_common_result(comparison_inputs, header, platform):
         """
-        Build the common result dictionary that is shared between Mann-Whitney U
-        and Student's t-test processing.
+        Build the common result shared between Mann-Whitney U and Student's t-test
+        processing.
 
-        Returns a tuple of:
-        (lower_is_better, statistics_base_perf_data, statistics_new_perf_data,
-         has_results, common_result)
+        Returns a ComparisonRow, or None when neither revision has data for this
+        (header, platform) pair.
         """
         sig_identifier = perfcompare_utils.get_sig_identifier(header, platform)
         base_sig = comparison_inputs.base.signatures_map.get(sig_identifier, {})
@@ -1519,28 +1530,9 @@ class PerfCompareResults(generics.ListAPIView):
         new_sig_id = new_sig.get("id", None)
 
         # Get signature-based properties
-        if base_sig:
-            (
-                extra_options,
-                lower_is_better,
-                option_name,
-                sig_hash,
-                suite,
-                test,
-            ) = PerfCompareResults._get_signature_based_properties(
-                base_sig, comparison_inputs.option_collection_map
-            )
-        else:
-            (
-                extra_options,
-                lower_is_better,
-                option_name,
-                sig_hash,
-                suite,
-                test,
-            ) = PerfCompareResults._get_signature_based_properties(
-                new_sig, comparison_inputs.option_collection_map
-            )
+        sig_info = PerfCompareResults._get_signature_based_properties(
+            base_sig or new_sig, comparison_inputs.option_collection_map
+        )
 
         # Extract performance data
         base_perf_data_values = comparison_inputs.base.values.get(base_sig_id, [])
@@ -1554,6 +1546,8 @@ class PerfCompareResults(generics.ListAPIView):
         base_runs_count = len(statistics_base_perf_data)
         new_runs_count = len(statistics_new_perf_data)
         has_results = base_runs_count or new_runs_count
+        if not has_results:
+            return None
 
         # Build common result dictionary (contains only data both test versions use)
         is_complete = base_runs_count and new_runs_count
@@ -1564,12 +1558,12 @@ class PerfCompareResults(generics.ListAPIView):
             "platform": platform,
             "base_app": base_sig.get("application", ""),
             "new_app": new_sig.get("application", ""),
-            "suite": suite,
-            "test": test,
+            "suite": sig_info.suite,
+            "test": sig_info.test,
             "is_complete": is_complete,
             "framework_id": comparison_inputs.framework,
-            "option_name": option_name,
-            "extra_options": extra_options,
+            "option_name": sig_info.option_name,
+            "extra_options": sig_info.extra_options,
             "base_repository_name": comparison_inputs.base.repo_name,
             "new_repository_name": comparison_inputs.new.repo_name,
             "base_measurement_unit": base_sig.get("measurement_unit", ""),
@@ -1585,7 +1579,7 @@ class PerfCompareResults(generics.ListAPIView):
                 comparison_inputs.new.rev,
                 str(comparison_inputs.framework),
                 comparison_inputs.push_timestamp,
-                str(sig_hash),
+                str(sig_info.signature_hash),
             ),
             "base_retriggerable_job_ids": comparison_inputs.base.job_ids.get(base_sig_id, []),
             "new_retriggerable_job_ids": comparison_inputs.new.job_ids.get(new_sig_id, []),
@@ -1598,28 +1592,26 @@ class PerfCompareResults(generics.ListAPIView):
             ),
         }
 
-        return (
-            lower_is_better,
-            statistics_base_perf_data,
-            statistics_new_perf_data,
-            has_results,
-            common_result,
+        return ComparisonRow(
+            stats_base=statistics_base_perf_data,
+            stats_new=statistics_new_perf_data,
+            header=header,
+            lower_is_better=sig_info.lower_is_better,
+            common=common_result,
         )
 
     @staticmethod
     def _get_signature_based_properties(sig, option_collection_map):
-        return (
-            sig.get("extra_options", ""),
-            sig.get("lower_is_better", ""),
-            PerfCompareResults._get_option_name(sig, option_collection_map),
-            sig.get("signature_hash", ""),
-            sig.get("suite", ""),
-            sig.get("test", ""),
-        )
+        option_collection_id = sig.get("option_collection_id", "")
 
-    @staticmethod
-    def _get_option_name(sig, option_collection_map):
-        return option_collection_map.get(sig.get("option_collection_id", ""), "")
+        return SignatureInfo(
+            extra_options=sig.get("extra_options", ""),
+            lower_is_better=sig.get("lower_is_better", ""),
+            option_name=option_collection_map.get(option_collection_id, ""),
+            signature_hash=sig.get("signature_hash", ""),
+            suite=sig.get("suite", ""),
+            test=sig.get("test", ""),
+        )
 
     @staticmethod
     def _get_push_timestamp(base_push, new_push):
@@ -1769,14 +1761,17 @@ class PerfCompareResults(generics.ListAPIView):
                 grouped_replicate_values[signature_id].append(replicate_value)
             else:
                 grouped_replicate_values[signature_id].append(value)
-        return grouped_job_ids, grouped_values, grouped_replicate_values
+        return GroupedPerfData(
+            values=grouped_values,
+            job_ids=grouped_job_ids,
+            replicates=grouped_replicate_values,
+        )
 
     @staticmethod
     def _get_signatures_map(signatures, grouped_values, option_collection_map):
         """
-        @return: signatures_map - contains a mapping of all the signatures for easy access and matching
-                 header_names - list of header names for all given signatures
-                 platforms - list of platforms for all given signatures
+        @return: SignaturesMap - mapping of all the signatures for easy access and
+                 matching, plus the header names and platforms for all given signatures
         """
         header_names = []
         platforms = []
@@ -1802,7 +1797,11 @@ class PerfCompareResults(generics.ListAPIView):
             header_names.append(header)
             platforms.append(platform)
 
-        return signatures_map, header_names, platforms
+        return SignaturesMap(
+            map=signatures_map,
+            header_names=header_names,
+            platforms=platforms,
+        )
 
     """
     _process_new_stats does the following for base and new:
@@ -1817,14 +1816,7 @@ class PerfCompareResults(generics.ListAPIView):
     """
 
     @staticmethod
-    def _process_mann_whitney_task(
-        statistics_base_perf_data,
-        statistics_new_perf_data,
-        header,
-        lower_is_better,
-        common_result,
-        enable_silverman_kde,
-    ):
+    def _process_mann_whitney_task(task):
         """
         Process a single mann-whitney-u test task for parallel execution.
         This is a static method so it can be pickled by multiprocessing.
@@ -1833,16 +1825,16 @@ class PerfCompareResults(generics.ListAPIView):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             new_stats = PerfCompareResults._process_stats(
-                statistics_base_perf_data,
-                statistics_new_perf_data,
-                header,
-                lower_is_better,
+                task.row.stats_base,
+                task.row.stats_new,
+                task.row.header,
+                task.row.lower_is_better,
                 remove_outliers=False,
-                enable_silverman_kde=enable_silverman_kde,
+                enable_silverman_kde=task.enable_silverman_kde,
             )
 
         row_result = {
-            **common_result,
+            **task.row.common,
             **new_stats,
         }
         return row_result

--- a/treeherder/webapp/api/performance_data.py
+++ b/treeherder/webapp/api/performance_data.py
@@ -1759,13 +1759,12 @@ class PerfCompareResults(generics.ListAPIView):
         grouped_replicate_values = defaultdict(list)
         grouped_values = defaultdict(list)
         grouped_job_ids = defaultdict(list)
-        for signature_id, value, job_id in perf_data.values_list("signature_id", "value", "job_id"):
+        for signature_id, value, job_id, replicate_value in perf_data.values_list(
+            "signature_id", "value", "job_id", "performancedatumreplicate__value"
+        ):
             if value is not None:
                 grouped_values[signature_id].append(value)
                 grouped_job_ids[signature_id].append(job_id)
-        for signature_id, value, replicate_value in perf_data.values_list(
-            "signature_id", "value", "performancedatumreplicate__value"
-        ):
             if replicate_value is not None:
                 grouped_replicate_values[signature_id].append(replicate_value)
             else:


### PR DESCRIPTION
Ticket: [Make more common methods for the MWU/T-test API code](https://bugzilla.mozilla.org/show_bug.cgi?id=2020493)

Follow up of #9779 

_How to review:_
Each commit can be reviewed by themselves, all of them are small commits with the exception of dbe892b886b87ce158fab31fe3c83e39520d97f0 which was required to be decent size due to the refactor.

Recommend `split view` to review but personal preference :)

Let me know if this is headed in the right direction, since I found it much easier to read without a long list of args being passed everywhere.