### PR TITLE
Bug 2068857 - Use the stored alert severity in the Alerts View instea…

### DIFF
--- a/tests/ui/mock/alert_summaries_with_critical_tests.json
+++ b/tests/ui/mock/alert_summaries_with_critical_tests.json
@@ -1,6 +1,7 @@
 [
   {
     "id": 45548,
+    "severity": "critical",
     "push_id": 1661657,
     "prev_push_id": 1661640,
     "original_revision": "8af8a47885e21ff463049676faa541b6f75c5011",
@@ -5873,6 +5874,7 @@
   },
   {
     "id": 44661,
+    "severity": "critical",
     "push_id": 1614225,
     "prev_push_id": 1614033,
     "original_revision": "74d8ffa093802fba0948d772a5adc22c3059b05e",

--- a/tests/ui/perfherder/alerts-view/alert_header_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alert_header_test.jsx
@@ -39,3 +39,25 @@ test("Critical badge is displayed near alert summary for 'speedometer3 score win
 
   expect(criticalTag.textContent).toBe('critical');
 });
+
+test('Sub-critical badge is displayed for a sub-critical summary', async () => {
+  const { findByText } = alertHeaderTitleTest({
+    ...testAlertSummaries[0],
+    severity: 'subcritical',
+  });
+
+  const severityTag = await waitFor(() => findByText('subcritical'));
+
+  expect(severityTag.textContent).toBe('subcritical');
+});
+
+test('Critical badge is not displayed for a normal summary', async () => {
+  const { queryByText, findByText } = alertHeaderTitleTest({
+    ...testAlertSummaries[0],
+    severity: 'normal',
+  });
+
+  await waitFor(() => findByText(/Alert #/));
+
+  expect(queryByText('critical')).toBeNull();
+});

--- a/tests/ui/perfherder/alerts-view/alerts_table_row_test.jsx
+++ b/tests/ui/perfherder/alerts-view/alerts_table_row_test.jsx
@@ -445,3 +445,26 @@ describe('graph link highlight', () => {
     expect(setLastClickedGraphAlertId).toHaveBeenCalledWith(testAlert.id);
   });
 });
+
+test.each(['critical', 'subcritical'])(
+  'Alert row is marked out when the alert is %s',
+  async (severity) => {
+    const { findByLabelText } = alertTableRowTest({
+      alert: { ...testAlert, severity },
+    });
+
+    const row = await findByLabelText('Alert table row');
+
+    expect(row).toHaveClass('alert-row-severe');
+  },
+);
+
+test('Alert row is not marked out for a normal alert', async () => {
+  const { findByLabelText } = alertTableRowTest({
+    alert: { ...testAlert, severity: 'normal' },
+  });
+
+  const row = await findByLabelText('Alert table row');
+
+  expect(row).not.toHaveClass('alert-row-severe');
+});

--- a/ui/css/perf.css
+++ b/ui/css/perf.css
@@ -680,6 +680,14 @@ li.pagination-active.active > button {
   flex: initial;
 }
 
+.alert-row-severe > td {
+  background-color: #fdf3f4;
+}
+
+.alert-row-severe > td:first-child {
+  border-left: 3px solid #dc3545 !important;
+}
+
 .alert-title-container {
   width: 250px;
 }

--- a/ui/perfherder/alerts/AlertHeaderTitle.jsx
+++ b/ui/perfherder/alerts/AlertHeaderTitle.jsx
@@ -7,6 +7,7 @@ import { Row, Col, Badge } from 'react-bootstrap';
 
 import Clipboard from '../../shared/Clipboard';
 import { getFrameworkName, getTitle } from '../perf-helpers/helpers';
+import { severeAlertSeverities } from '../perf-helpers/constants';
 
 export default class AlertHeaderTitle extends React.Component {
   constructor(props) {
@@ -18,7 +19,7 @@ export default class AlertHeaderTitle extends React.Component {
     const { alertSummary, frameworks } = this.props;
 
     const { severity } = alertSummary;
-    const showSeverity = ['critical', 'subcritical'].includes(severity);
+    const showSeverity = severeAlertSeverities.includes(severity);
 
     return (
       <Row>

--- a/ui/perfherder/alerts/AlertHeaderTitle.jsx
+++ b/ui/perfherder/alerts/AlertHeaderTitle.jsx
@@ -14,28 +14,11 @@ export default class AlertHeaderTitle extends React.Component {
     this.state = {};
   }
 
-  isAlertSummaryCritical = (alertSummary) => {
-    const { alerts } = alertSummary;
-
-    const criticalTests = [
-      'speedometer3 score windows11-64-24h2-shippable',
-      'newssite-applink-startup applink_startup android-hw-a55-14-0-aarch64-shippable',
-    ];
-
-    const isCritical = alerts.some((alert) => {
-      const { series_signature: seriesSignature } = alert;
-      const { suite, test, machine_platform: platform } = seriesSignature;
-
-      return criticalTests.includes(`${suite} ${test} ${platform}`);
-    });
-
-    return isCritical;
-  };
-
   render() {
     const { alertSummary, frameworks } = this.props;
 
-    const isCritical = this.isAlertSummaryCritical(alertSummary);
+    const { severity } = alertSummary;
+    const showSeverity = ['critical', 'subcritical'].includes(severity);
 
     return (
       <Row>
@@ -51,9 +34,9 @@ export default class AlertHeaderTitle extends React.Component {
               <Badge bg="secondary" text="white" className="flex-shrink-0 mt-1">
                 {getFrameworkName(frameworks, alertSummary.framework)}
               </Badge>
-              {isCritical ? (
+              {showSeverity ? (
                 <Badge bg="danger" className="flex-shrink-0 mt-1">
-                  critical
+                  {severity}
                 </Badge>
               ) : null}
               <span>

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -397,6 +397,8 @@ export default class AlertTableRow extends React.Component {
       !browsertimeBenchmarksTests.includes(alert.series_signature.suite) &&
       alert.side_by_side_available;
 
+    const isSevere = ['critical', 'subcritical'].includes(alert.severity);
+
     const backfillStatusInfo = this.getBackfillStatusInfo(alert);
     let sherlockTooltip = backfillStatusInfo?.message;
     if (backfillStatusInfo?.displayTasksCount) {
@@ -418,7 +420,7 @@ export default class AlertTableRow extends React.Component {
       <tr
         className={`align-middle ${
           alertSummary.notes ? 'border-top border-start border-end' : 'border'
-        }`}
+        }${isSevere ? ' alert-row-severe' : ''}`}
         aria-label="Alert table row"
         data-testid={alert.id}
       >

--- a/ui/perfherder/alerts/AlertTableRow.jsx
+++ b/ui/perfherder/alerts/AlertTableRow.jsx
@@ -34,6 +34,7 @@ import {
   browsertimeId,
   browsertimeEssentialTests,
   browsertimeBenchmarksTests,
+  severeAlertSeverities,
 } from '../perf-helpers/constants';
 import { Perfdocs } from '../perf-helpers/perfdocs';
 
@@ -397,7 +398,7 @@ export default class AlertTableRow extends React.Component {
       !browsertimeBenchmarksTests.includes(alert.series_signature.suite) &&
       alert.side_by_side_available;
 
-    const isSevere = ['critical', 'subcritical'].includes(alert.severity);
+    const isSevere = severeAlertSeverities.includes(alert.severity);
 
     const backfillStatusInfo = this.getBackfillStatusInfo(alert);
     let sherlockTooltip = backfillStatusInfo?.message;

--- a/ui/perfherder/perf-helpers/constants.js
+++ b/ui/perfherder/perf-helpers/constants.js
@@ -331,3 +331,5 @@ export const criticalTestsList = {
   browsertime: 'Speedometer 3 on Windows 11',
   mozperftest: 'NewsSite Applink Startup on Android A55',
 };
+
+export const severeAlertSeverities = ['critical', 'subcritical'];


### PR DESCRIPTION

<img width="1311" height="620" alt="image" src="https://github.com/user-attachments/assets/26d01a2d-08b6-41af-8448-02784ba780e6" />
<img width="1352" height="545" alt="image" src="https://github.com/user-attachments/assets/3bc8cc9a-9f92-41e6-80d5-05735a07c482" />

Bug 2068857 - Use the stored alert severity in the Alerts View instead of a hardcoded test list.