### PR TITLE
Stream errorsummary logs and use a 1 MB iter_lines chunk

### DIFF
--- a/tests/log_parser/test_artifact_builder_collection.py
+++ b/tests/log_parser/test_artifact_builder_collection.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 import responses
 
 from tests.test_utils import add_log_response
@@ -69,3 +70,24 @@ def test_log_download_size_limit():
 
     with pytest.raises(LogSizeError):
         lpc.parse()
+
+
+@responses.activate
+def test_parse_uses_large_iter_lines_chunk(monkeypatch):
+    """`iter_lines()` with its default 512-byte chunk is quadratic on long lines,
+    so the log must be streamed with the shared large chunk size."""
+    from treeherder.utils.http import ITER_LINES_CHUNK_SIZE
+
+    seen = {}
+    original = requests.Response.iter_lines
+
+    def spy(self, *args, **kwargs):
+        seen.update(kwargs)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(requests.Response, "iter_lines", spy)
+    url = add_log_response("win-aarch64-build.txt.gz")
+
+    ArtifactBuilderCollection(url).parse()
+
+    assert seen == {"chunk_size": ITER_LINES_CHUNK_SIZE}

--- a/tests/log_parser/test_store_failure_lines.py
+++ b/tests/log_parser/test_store_failure_lines.py
@@ -512,3 +512,98 @@ def test_store_error_summary_known_intermittent(activate_responses, test_reposit
 
     failure = FailureLine.objects.first()
     assert failure.known_intermittent == ["FAIL", "TIMEOUT"]
+
+
+class FakeStreamingResponse:
+    """Stand-in for a `requests.Response` opened with ``stream=True``.
+
+    Yields ``lines`` lazily and fails loudly if the caller reads past them, so a
+    test can prove the consumer stops reading once it has what it needs.
+    """
+
+    def __init__(self, lines):
+        self.lines = lines
+        self.iter_lines_kwargs = None
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.close()
+
+    def close(self):
+        self.closed = True
+
+    def iter_lines(self, **kwargs):
+        self.iter_lines_kwargs = kwargs
+        yield from self.lines
+        raise AssertionError("read past the last line the consumer should need")
+
+
+def test_fetch_log_streams_and_stops_at_cutoff(test_job, monkeypatch):
+    """The errorsummary log must be streamed line by line (never loaded whole)
+    and reading must stop once FAILURE_LINES_CUTOFF + 1 lines are consumed."""
+    from treeherder.log_parser import failureline
+    from treeherder.utils.http import ITER_LINES_CHUNK_SIZE
+
+    cutoff = 5
+    monkeypatch.setattr(settings, "FAILURE_LINES_CUTOFF", cutoff)
+
+    lines = [
+        json.dumps({"action": "log", "line": i, "level": "ERROR", "message": f"m{i}"}).encode()
+        for i in range(cutoff + 1)
+    ]
+    fake = FakeStreamingResponse(lines)
+    calls = []
+
+    def fake_make_request(url, **kwargs):
+        calls.append((url, kwargs))
+        return fake
+
+    monkeypatch.setattr(failureline, "make_request", fake_make_request)
+    log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url="http://x/es.log")
+
+    store_failure_lines(log_obj)
+
+    assert calls == [("http://x/es.log", {"stream": True})]
+    assert fake.iter_lines_kwargs == {"chunk_size": ITER_LINES_CHUNK_SIZE}
+    assert fake.closed
+    assert FailureLine.objects.count() == cutoff + 1
+    assert FailureLine.objects.filter(action="truncated").count() == 1
+
+
+def test_store_error_summary_blank_lines_and_unicode_line_separator(
+    activate_responses, test_repository, test_job
+):
+    """Blank lines are skipped and a JSON string containing U+2028 (which
+    str.splitlines() treats as a line break) must not split the record."""
+    log_url = "http://my-log.mozilla.org"
+    first = {"action": "log", "line": 1, "level": "ERROR", "message": "first"}
+    second = {"action": "log", "line": 2, "level": "ERROR", "message": "a b"}
+    body = json.dumps(first) + "\n\n" + json.dumps(second, ensure_ascii=False) + "\n"
+    responses.add(
+        responses.GET,
+        log_url,
+        content_type="text/plain;charset=utf-8",
+        body=body.encode("utf-8"),
+        status=200,
+    )
+    log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
+
+    store_failure_lines(log_obj)
+
+    assert FailureLine.objects.count() == 2
+    assert FailureLine.objects.get(line=2).message == "a b"
+
+
+def test_store_error_summary_empty_body(activate_responses, test_repository, test_job):
+    """An empty errorsummary log stores nothing and leaves the log pending."""
+    log_url = "http://my-log.mozilla.org"
+    responses.add(responses.GET, log_url, body="", status=200)
+    log_obj = JobLog.objects.create(job=test_job, name="errorsummary_json", url=log_url)
+
+    assert store_failure_lines(log_obj) is None
+    assert FailureLine.objects.count() == 0
+    log_obj.refresh_from_db()
+    assert log_obj.status == JobLog.PENDING

--- a/tests/sample_data/logs/wpt-multiple.logview.json
+++ b/tests/sample_data/logs/wpt-multiple.logview.json
@@ -2,143 +2,143 @@
   "logurl": "http://my-log.mozilla.org/wpt-multiple.log.gz",
   "errors": [
     {
-      "linenumber": 6932,
+      "linenumber": 6931,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished moving, that file can have an open access handle in readwrite-unsafe mode - promise_rejects_dom: function \"function() { throw e }\" threw object \"NotFoundError: Entry not found\" that is not a DOMException NoModificationAllowedError: property \"code\" is equal to 8, expected 7"
     },
     {
-      "linenumber": 6935,
+      "linenumber": 6934,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file cannot be moved to a location with an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6938,
+      "linenumber": 6937,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode cannot be moved - expected NOTRUN"
     },
     {
-      "linenumber": 6941,
+      "linenumber": 6940,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with moving another file - expected NOTRUN"
     },
     {
-      "linenumber": 6944,
+      "linenumber": 6943,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After an open access handle in readwrite-unsafe mode on a file has been closed, that file can be moved - expected NOTRUN"
     },
     {
-      "linenumber": 6947,
+      "linenumber": 6946,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing remove operation does not interfere with the creation of an open access handle in readwrite-unsafe mode on another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6950,
+      "linenumber": 6949,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished being removed, that file can have an open access handle in readwrite-unsafe mode - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6953,
+      "linenumber": 6952,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A directory cannot be removed if it contains a file that has an open access handle in readwrite-unsafe mode. - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6956,
+      "linenumber": 6955,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode cannot be removed - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6959,
+      "linenumber": 6958,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with removing another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6962,
+      "linenumber": 6961,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After an open access handle in readwrite-unsafe mode on a file has been closed, that file can be removed - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 6965,
+      "linenumber": 6964,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in siloed mode on a file, cannot have an open access handle in readwrite-unsafe mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6968,
+      "linenumber": 6967,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in siloed mode does not interfere with an open access handle in readwrite-unsafe mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6971,
+      "linenumber": 6970,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After all writable streams in siloed mode have been closed for a file, that file can have an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6974,
+      "linenumber": 6973,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open access handle in readwrite-unsafe mode on a file, cannot open an open writable stream in siloed mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6977,
+      "linenumber": 6976,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with the creation of an open writable stream in siloed mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6980,
+      "linenumber": 6979,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in exclusive mode on a file, cannot have an open access handle in readwrite-unsafe mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6983,
+      "linenumber": 6982,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in exclusive mode does not interfere with an open access handle in readwrite-unsafe mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6986,
+      "linenumber": 6985,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a writable stream in exclusive mode has been closed for a file, that file can have an open access handle in readwrite-unsafe mode - expected NOTRUN"
     },
     {
-      "linenumber": 6989,
+      "linenumber": 6988,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open access handle in readwrite-unsafe mode on a file, cannot open an open writable stream in exclusive mode on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 6992,
+      "linenumber": 6991,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open access handle in readwrite-unsafe mode does not interfere with the creation of an open writable stream in exclusive mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6995,
+      "linenumber": 6994,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing move operation does not interfere with an open writable stream in siloed mode on another file - expected NOTRUN"
     },
     {
-      "linenumber": 6998,
+      "linenumber": 6997,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished moving, that file can have an open writable stream in siloed mode - promise_rejects_dom: function \"function() { throw e }\" threw object \"NotFoundError: Entry not found\" that is not a DOMException NoModificationAllowedError: property \"code\" is equal to 8, expected 7"
     },
     {
-      "linenumber": 7001,
+      "linenumber": 7000,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file cannot be moved to a location with an open writable stream in siloed mode - expected NOTRUN"
     },
     {
-      "linenumber": 7004,
+      "linenumber": 7003,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | When there's an open writable stream in siloed mode on a file, cannot have an ongoing move operation on that same file - expected NOTRUN"
     },
     {
-      "linenumber": 7007,
+      "linenumber": 7006,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an open writable stream in siloed mode does not interfere with an ongoing move operation on another file - expected NOTRUN"
     },
     {
-      "linenumber": 7010,
+      "linenumber": 7009,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-PASS | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After all writable streams in siloed mode have been closed for a file, that file can have an ongoing move operation - expected NOTRUN"
     },
     {
-      "linenumber": 7013,
+      "linenumber": 7012,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | A file with an ongoing remove operation does not interfere with the creation of an open writable stream in siloed mode on another file - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 7016,
+      "linenumber": 7015,
       "line": "23:52:10     INFO - TEST-UNEXPECTED-FAIL | /fs/FileSystemFileHandle-cross-primitive-locking.https.tentative.worker.html | After a file has finished being removed, that file can have an open writable stream in siloed mode - promise_test: Unhandled rejection with value: object \"TypeError: fileHandle.remove is not a function\""
     },
     {
-      "linenumber": 15089,
+      "linenumber": 15088,
       "line": "00:01:58     INFO - KeyError: 261"
     },
     {
-      "linenumber": 15117,
+      "linenumber": 15116,
       "line": "00:01:58     INFO - KeyError: 275"
     },
     {
-      "linenumber": 17469,
+      "linenumber": 17468,
       "line": "00:05:10  WARNING - KeyError: 'bidi.bluetooth.simulate_adapter'"
     },
     {
-      "linenumber": 17482,
+      "linenumber": 17481,
       "line": "00:05:10  WARNING - ValueError: Unknown action bidi.bluetooth.simulate_adapter"
     },
     {
-      "linenumber": 17518,
+      "linenumber": 17517,
       "line": "00:05:15  WARNING - KeyError: 'bidi.permissions.set_permission'"
     },
     {
-      "linenumber": 17531,
+      "linenumber": 17530,
       "line": "00:05:15  WARNING - ValueError: Unknown action bidi.permissions.set_permission"
     }
   ]

--- a/treeherder/log_parser/artifactbuildercollection.py
+++ b/treeherder/log_parser/artifactbuildercollection.py
@@ -2,7 +2,7 @@ import logging
 
 import newrelic.agent
 
-from treeherder.utils.http import make_request
+from treeherder.utils.http import ITER_LINES_CHUNK_SIZE, make_request
 
 from .artifactbuilders import LogViewerArtifactBuilder, PerformanceDataArtifactBuilder
 from .parsers import EmptyPerformanceDataError
@@ -98,7 +98,7 @@ class ArtifactBuilderCollection:
             # and we cannot use its `decode_unicode=True` mode, since otherwise Unicode newline
             # characters such as `\u0085` (which can appear in test output) are treated the same
             # as `\n` or `\r`, and so split into unwanted additional lines by `iter_lines()`.
-            for line in response.iter_lines():
+            for line in response.iter_lines(chunk_size=ITER_LINES_CHUNK_SIZE):
                 for builder in self.builders:
                     try:
                         # Using `replace` to prevent malformed unicode (which might possibly exist

--- a/treeherder/log_parser/failureline.py
+++ b/treeherder/log_parser/failureline.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections import defaultdict
+from contextlib import closing
 from itertools import islice
 
 import newrelic.agent
@@ -11,7 +12,7 @@ from requests.exceptions import HTTPError
 
 from treeherder.etl.text import astral_filter
 from treeherder.model.models import FailureLine, Group, GroupStatus, JobLog
-from treeherder.utils.http import fetch_text
+from treeherder.utils.http import ITER_LINES_CHUNK_SIZE, make_request
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +21,23 @@ def store_failure_lines(job_log):
     log_iter = fetch_log(job_log)
     if not log_iter:
         return False
-    return write_failure_lines(job_log, log_iter)
+    # Only FAILURE_LINES_CUTOFF + 1 records are consumed; close the streamed
+    # response as soon as they are, rather than when the generator is collected.
+    with closing(log_iter):
+        return write_failure_lines(job_log, log_iter)
 
 
 def fetch_log(job_log):
+    """Return an iterator of parsed JSON records from the errorsummary log, or
+    ``None`` if the log is missing or empty.
+
+    The log is streamed line by line rather than downloaded whole: only
+    ``FAILURE_LINES_CUTOFF + 1`` records are ever consumed, and a large
+    errorsummary log would otherwise cost several times its decompressed size
+    in memory before the first line is parsed.
+    """
     try:
-        log_text = fetch_text(job_log.url)
+        response = make_request(job_log.url, stream=True)
     except HTTPError as e:
         job_log.update_status(JobLog.FAILED)
         if e.response is not None and e.response.status_code in (403, 404):
@@ -33,10 +45,36 @@ def fetch_log(job_log):
             return
         raise
 
-    if not log_text:
+    log_iter = _iter_json_lines(response)
+    try:
+        first = next(log_iter)
+    except StopIteration:
         return
 
-    return (json.loads(item) for item in log_text.splitlines())
+    return _prepend(first, log_iter)
+
+
+def _prepend(first, rest):
+    """Yield ``first`` then everything from ``rest``, closing ``rest`` (and
+    with it the underlying HTTP response) when this generator is closed."""
+    try:
+        yield first
+        yield from rest
+    finally:
+        rest.close()
+
+
+def _iter_json_lines(response):
+    """Yield one parsed JSON object per non-blank line of a streamed response,
+    closing the connection when the consumer stops iterating."""
+    with response:
+        for raw_line in response.iter_lines(chunk_size=ITER_LINES_CHUNK_SIZE):
+            # Decode per line (rather than using ``response.text``) so unicode line
+            # separators inside a JSON string are not treated as record boundaries,
+            # and so malformed bytes cannot break the rest of the log.
+            line = raw_line.decode("utf-8", "replace").strip()
+            if line:
+                yield json.loads(line)
 
 
 def write_failure_lines(job_log, log_iter):

--- a/treeherder/utils/http.py
+++ b/treeherder/utils/http.py
@@ -2,6 +2,12 @@ import newrelic.agent
 import requests
 from django.conf import settings
 
+# Chunk size for `Response.iter_lines()` when streaming logs. The default (512 bytes)
+# re-concatenates the pending partial line on every chunk, which is quadratic in the
+# length of a single line: an 8 MB line takes ~20 s and hundreds of MB, and a multi-MB
+# PERFHERDER_DATA line can run for many minutes. A 1 MB chunk makes it linear.
+ITER_LINES_CHUNK_SIZE = 1024 * 1024
+
 
 def make_request(url, method="GET", headers=None, timeout=30, **kwargs):
     """A wrapper around requests to set defaults & call raise_for_status()."""


### PR DESCRIPTION
## Problem

Investigating log-parser OOMs turned up two reproducible memory problems in the parsing path (no per-task leak was found in 300 replays of the real `parse_logs` task on Linux):

1. **The structured errorsummary log was downloaded whole with no size cap.** `fetch_log` went `fetch_text` -> `response.text` -> `splitlines()`, so a log cost ~2x its decompressed size before the first record was parsed, even though only `FAILURE_LINES_CUTOFF + 1` records are ever used.
2. **`requests.iter_lines()` with its default 512-byte chunk is quadratic in line length**, because the pending partial line is re-concatenated on every chunk. A multi-MB `PERFHERDER_DATA` line could run for many minutes and hundreds of MB to GBs of memory.

## Changes

- `failureline.fetch_log` opens the response with `stream=True`, decodes and JSON-parses one line at a time, skips blank lines, and closes the connection as soon as the consumer has its `FAILURE_LINES_CUTOFF + 1` records. Empty logs and HTTP error handling behave as before. Decoding per line also stops a unicode line separator inside a JSON string from splitting a record (the old `str.splitlines()` did).
- A shared `ITER_LINES_CHUNK_SIZE = 1 MB` in `treeherder/utils/http.py`, passed to `iter_lines()` on both the errorsummary and `live_backing_log` paths.
- Tests for streaming with early stop, the chunk size on the raw path, blank lines / U+2028, and the empty-body case.

## Measured (local harness, same inputs before and after)

| input | before | after |
|---|---|---|
| 1 GB errorsummary, peak RSS | 4,878 MB | 112 MB |
| 100 MB errorsummary, peak RSS | 586 MB | 113 MB |
| 72 MB single PERFHERDER_DATA line | killed after >13 min | 89 s |

## Fixture change

With 512-byte chunks, `iter_lines()` emitted a phantom empty line whenever a chunk boundary split a `\r\n` pair (29 of them in the `wpt-multiple` sample). That put parser line numbers out of step with the log viewer's `/\r\n|\r|\n/` splitting. The 1 MB chunk matches whole-file `bytes.splitlines()` for that sample, so `wpt-multiple.logview.json` is regenerated; only `linenumber` values changed (each by -1). This is a small correctness improvement for error highlighting on CRLF logs.

## Not in this PR

- A cap on a single `PERFHERDER_DATA` line's length (a 72 MB line still peaks high inside `json.loads` + jsonschema).
- A custom line iterator that holds back a trailing `\r` so numbering is deterministic at any chunk boundary.
- Worker recycling (`--max-tasks-per-child` / `--max-memory-per-child`) and per-task memory telemetry.
